### PR TITLE
Fix form to correctly set lti_type radio buttons.

### DIFF
--- a/client/js/_admin/components/application_instances/form.jsx
+++ b/client/js/_admin/components/application_instances/form.jsx
@@ -41,17 +41,20 @@ export default class Form extends React.Component {
     this.props.onChange(event);
   }
 
-  renderInput(outerClassName, className, type, fieldLabel, field) {
+  renderInput(outerClassName, className, type, altName, fieldLabel, field) {
+    const id = `instance_${field}`;
+    const name = altName || field;
+    const value = type === 'radio' ? field : this.props[field] || '';
     return (
       <div key={field} className={outerClassName}>
         <Input
           className={className}
           labelText={fieldLabel}
           inputProps={{
-            id:       `instance_${field}`,
-            name:     field,
+            id,
+            name,
             type,
-            value:    this.props[field] || '',
+            value,
             onChange: this.props.onChange
           }}
         />
@@ -87,11 +90,19 @@ export default class Form extends React.Component {
               />
             </div>
           </div>
-          { _.map(TEXT_FIELDS, (...args) => this.renderInput('o-grid__item u-half', 'c-input', 'text', ...args)) }
+          {
+            _.map(TEXT_FIELDS, (...args) =>
+              this.renderInput('o-grid__item u-half', 'c-input', 'text', undefined, ...args)
+            )
+          }
         </div>
         <h3 className="c-modal__subtitle">Install Settings</h3>
         <div className="o-grid o-grid__bottom">
-          { _.map(TYPE_RADIOS, (...args) => this.renderInput('o-grid__item u-third', 'c-checkbox', 'radio', ...args)) }
+          {
+            _.map(TYPE_RADIOS, (...args) =>
+              this.renderInput('o-grid__item u-third', 'c-checkbox', 'radio', 'lti_type', ...args)
+            )
+          }
         </div>
         <button
           type="button"

--- a/client/js/_admin/components/application_instances/form.spec.jsx
+++ b/client/js/_admin/components/application_instances/form.spec.jsx
@@ -46,7 +46,8 @@ describe('application instance form', () => {
         const inputs = TestUtils.scryRenderedDOMComponentsWithTag(result, 'input');
         const input = _.find(inputs, { id: `instance_${field}` });
         expect(input).toBeDefined();
-        expect(input.name).toBe(field);
+        expect(input.name).toBe('lti_type');
+        expect(input.value).toBe(field);
         expect(input.type).toBe('radio');
       });
     });


### PR DESCRIPTION
Previously they were not getting assigned the same name. Thus you could select all 3 types. The next problem was the value wasn't getting set to anything. This fixes both issues.

![lti_type](https://cloud.githubusercontent.com/assets/1216167/22976771/69ea43f2-f349-11e6-968f-a41c4d06c6e9.gif)
