### PR TITLE
Add ability to update app instances

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -27,6 +27,11 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
     render json: @application_instance.as_json(include: :site)
   end
 
+  def update
+    @application_instance.update(application_instance_params)
+    respond_with(@application_instance)
+  end
+
   def destroy
     @application_instance.destroy
     render json: { head: :ok }

--- a/client/js/_admin/actions/application_instances.js
+++ b/client/js/_admin/actions/application_instances.js
@@ -9,7 +9,8 @@ const requests = [
   'GET_APPLICATION_INSTANCES',
   'GET_APPLICATION_INSTANCE',
   'CREATE_APPLICATION_INSTANCE',
-  'DELETE_APPLICATION_INSTANCE'
+  'DELETE_APPLICATION_INSTANCE',
+  'SAVE_APPLICATION_INSTANCE',
 ];
 
 export const Constants = wrapper(actions, requests);
@@ -36,6 +37,17 @@ export function createApplicationInstance(applicationId, applicationInstance) {
     method : Network.POST,
     url    : `/api/applications/${applicationId}/application_instances`,
     body   : {
+      application_instance: applicationInstance,
+    }
+  };
+}
+
+export function saveApplicationInstance(applicationId, applicationInstance) {
+  return {
+    type: Constants.SAVE_APPLICATION_INSTANCE,
+    method: Network.PUT,
+    url: `/api/applications/${applicationId}/application_instances/${applicationInstance.id}`,
+    body: {
       application_instance: applicationInstance,
     }
   };

--- a/client/js/_admin/components/application_instances/form.jsx
+++ b/client/js/_admin/components/application_instances/form.jsx
@@ -23,7 +23,8 @@ export default class Form extends React.Component {
     createInstance: React.PropTypes.func.isRequired,
     newSite:        React.PropTypes.func.isRequired,
     site_id:        React.PropTypes.string,
-    sites:          React.PropTypes.shape({})
+    sites:          React.PropTypes.shape({}),
+    isUpdate:       React.PropTypes.bool,
   };
 
   selectSite(option) {
@@ -41,7 +42,7 @@ export default class Form extends React.Component {
     this.props.onChange(event);
   }
 
-  renderInput(outerClassName, className, type, altName, fieldLabel, field) {
+  renderInput(outerClassName, className, type, altName, isUpdate, fieldLabel, field) {
     const id = `instance_${field}`;
     const name = altName || field;
     const inputProps = {
@@ -54,6 +55,9 @@ export default class Form extends React.Component {
       inputProps.checked = this.props[altName] === field;
       inputProps.value = field;
     } else {
+      if (isUpdate && field === 'lti_key') {
+        inputProps.disabled = true;
+      }
       inputProps.value = this.props[field] || '';
     }
     return (
@@ -97,7 +101,7 @@ export default class Form extends React.Component {
           </div>
           {
             _.map(TEXT_FIELDS, (...args) =>
-              this.renderInput('o-grid__item u-half', 'c-input', 'text', undefined, ...args)
+              this.renderInput('o-grid__item u-half', 'c-input', 'text', undefined, this.props.isUpdate, ...args)
             )
           }
         </div>
@@ -105,7 +109,7 @@ export default class Form extends React.Component {
         <div className="o-grid o-grid__bottom">
           {
             _.map(TYPE_RADIOS, (...args) =>
-              this.renderInput('o-grid__item u-third', 'c-checkbox', 'radio', 'lti_type', ...args)
+              this.renderInput('o-grid__item u-third', 'c-checkbox', 'radio', 'lti_type', this.props.isUpdate, ...args)
             )
           }
         </div>

--- a/client/js/_admin/components/application_instances/form.jsx
+++ b/client/js/_admin/components/application_instances/form.jsx
@@ -44,19 +44,24 @@ export default class Form extends React.Component {
   renderInput(outerClassName, className, type, altName, fieldLabel, field) {
     const id = `instance_${field}`;
     const name = altName || field;
-    const value = type === 'radio' ? field : this.props[field] || '';
+    const inputProps = {
+      id,
+      name,
+      type,
+      onChange: this.props.onChange
+    };
+    if (type === 'radio') {
+      inputProps.checked = this.props[altName] === field;
+      inputProps.value = field;
+    } else {
+      inputProps.value = this.props[field] || '';
+    }
     return (
       <div key={field} className={outerClassName}>
         <Input
           className={className}
           labelText={fieldLabel}
-          inputProps={{
-            id,
-            name,
-            type,
-            value,
-            onChange: this.props.onChange
-          }}
+          inputProps={inputProps}
         />
       </div>
     );

--- a/client/js/_admin/components/application_instances/index.jsx
+++ b/client/js/_admin/components/application_instances/index.jsx
@@ -23,6 +23,7 @@ export class Index extends React.Component {
     getApplicationInstances: React.PropTypes.func.isRequired,
     createApplicationInstance: React.PropTypes.func,
     deleteApplicationInstance: React.PropTypes.func,
+    saveApplicationInstance: React.PropTypes.func,
     sites: React.PropTypes.shape({}).isRequired,
     applications: React.PropTypes.shape({}).isRequired,
     params: React.PropTypes.shape({
@@ -41,6 +42,7 @@ export class Index extends React.Component {
   }
 
   render() {
+    const application = this.props.applications[this.props.params.applicationId];
     return (
       <div>
         <Heading
@@ -49,20 +51,22 @@ export class Index extends React.Component {
         <div className="o-contain o-contain--full">
           <Modal
             isOpen={this.state.modalOpen}
-            applicationInstances={this.props.applicationInstances}
             closeModal={() => this.setState({ modalOpen: false })}
             sites={this.props.sites}
-            createApplicationInstance={this.props.createApplicationInstance}
-            application={this.props.applications[this.props.params.applicationId]}
+            save={this.props.createApplicationInstance}
+            application={application}
           />
           <Header
             openSettings={() => {}}
             newApplicationInstance={() => this.setState({ modalOpen: true })}
-            application={this.props.applications[this.props.params.applicationId]}
+            application={application}
           />
           <List
             applicationInstances={this.props.applicationInstances}
             settings={this.props.settings}
+            sites={this.props.sites}
+            application={application}
+            saveApplicationInstance={this.props.saveApplicationInstance}
             deleteApplicationInstance={this.props.deleteApplicationInstance}
           />
         </div>

--- a/client/js/_admin/components/application_instances/index.spec.jsx
+++ b/client/js/_admin/components/application_instances/index.spec.jsx
@@ -13,6 +13,7 @@ describe('application instances index', () => {
     applicationInstances: [],
     getApplicationInstances: () => { applicationInstances = true; },
     createApplicationInstance: () => {},
+    saveApplicationInstance: () => {},
     deleteApplicationInstance: () => {},
     sites: {},
     applications: {},

--- a/client/js/_admin/components/application_instances/input.jsx
+++ b/client/js/_admin/components/application_instances/input.jsx
@@ -26,7 +26,8 @@ Input.propTypes = {
   inputProps: React.PropTypes.shape({
     id: React.PropTypes.string,
     value: React.PropTypes.string,
-    checked:  React.PropTypes.bool,
+    checked: React.PropTypes.bool,
+    disabled: React.PropTypes.bool,
     name: React.PropTypes.string,
     type: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,

--- a/client/js/_admin/components/application_instances/list.jsx
+++ b/client/js/_admin/components/application_instances/list.jsx
@@ -10,6 +10,7 @@ export default function List(props) {
           <th><span>INSTANCE</span></th>
           <th><span>LTI KEY</span></th>
           <th><span>DOMAIN</span></th>
+          <th><span>SETTINGS</span></th>
           <th />
         </tr>
       </thead>
@@ -19,7 +20,11 @@ export default function List(props) {
             <ListRow
               key={`instance_${key}`}
               {...instance}
+              application={props.application}
+              applicationInstance={instance}
               settings={props.settings}
+              sites={props.sites}
+              save={props.saveApplicationInstance}
               delete={props.deleteApplicationInstance}
             />
           ))
@@ -32,5 +37,8 @@ export default function List(props) {
 List.propTypes = {
   applicationInstances: React.PropTypes.arrayOf(React.PropTypes.shape({})).isRequired,
   settings: React.PropTypes.shape({}).isRequired,
+  sites: React.PropTypes.shape({}).isRequired,
+  application: React.PropTypes.shape({}),
+  saveApplicationInstance: React.PropTypes.func.isRequired,
   deleteApplicationInstance: React.PropTypes.func.isRequired,
 };

--- a/client/js/_admin/components/application_instances/list.spec.jsx
+++ b/client/js/_admin/components/application_instances/list.spec.jsx
@@ -10,6 +10,8 @@ describe('application instances list', () => {
     applicationInstances: [],
     settings: {},
     deleteApplicationInstance: () => {},
+    saveApplicationInstance: () => {},
+    sites: { 1: { id: 1, url: 'http://www.example.com' } },
   };
 
   beforeEach(() => {

--- a/client/js/_admin/components/application_instances/list_row.jsx
+++ b/client/js/_admin/components/application_instances/list_row.jsx
@@ -1,11 +1,13 @@
 import React          from 'react';
 import { Link }       from 'react-router';
 import _              from 'lodash';
+import Modal          from './modal';
 import SettingsInputs from '../common/settings_inputs';
 
 export default class ListRow extends React.Component {
   static propTypes = {
     delete: React.PropTypes.func.isRequired,
+    save: React.PropTypes.func.isRequired,
     lti_key: React.PropTypes.string,
     domain: React.PropTypes.string,
     id: React.PropTypes.number.isRequired,
@@ -13,11 +15,31 @@ export default class ListRow extends React.Component {
     site: React.PropTypes.shape({
       url: React.PropTypes.string
     }).isRequired,
+    sites: React.PropTypes.shape({}).isRequired,
+    application: React.PropTypes.shape({}),
+    applicationInstance: React.PropTypes.shape({}).isRequired,
     settings: React.PropTypes.shape({
       lti_key: React.PropTypes.string,
       user_canvas_domains: React.PropTypes.arrayOf(React.PropTypes.string),
     }).isRequired
   };
+
+  static getStyles() {
+    return {
+      buttonIcon: {
+        border: 'none',
+        backgroundColor: 'transparent',
+        color: 'grey',
+        fontSize: '1.5em',
+        cursor: 'pointer',
+      }
+    };
+  }
+
+  constructor() {
+    super();
+    this.state = { modalOpen: false };
+  }
 
   checkAuthentication(e) {
     if (!_.find(this.props.settings.user_canvas_domains, canvasUrl =>
@@ -30,6 +52,7 @@ export default class ListRow extends React.Component {
   }
 
   render() {
+    const styles = ListRow.getStyles();
     const path = `applications/${this.props.application_id}/application_instances/${this.props.id}/installs`;
     return (
       <tr>
@@ -60,6 +83,22 @@ export default class ListRow extends React.Component {
         </td>
         <td><span>{this.props.lti_key}</span></td>
         <td><span>{this.props.domain}</span></td>
+        <td>
+          <button
+            style={styles.buttonIcon}
+            onClick={() => this.setState({ modalOpen: true })}
+          >
+            <i className="i-settings" />
+          </button>
+          <Modal
+            isOpen={this.state.modalOpen}
+            closeModal={() => this.setState({ modalOpen: false })}
+            sites={this.props.sites}
+            save={this.props.save}
+            application={this.props.application}
+            applicationInstance={this.props.applicationInstance}
+          />
+        </td>
         <td>
           <button
             className="c-delete"

--- a/client/js/_admin/components/application_instances/list_row.spec.jsx
+++ b/client/js/_admin/components/application_instances/list_row.spec.jsx
@@ -12,11 +12,14 @@ describe('application instances list row', () => {
 
   const props = {
     delete: () => { deleted = true; },
+    save: () => {},
     lti_key: 'lti-key',
     domain: 'www.example.com',
     id: 2,
     application_id: 23,
     site: { url: 'http://www.example.com' },
+    sites: { 1: { id: 1, url: 'http://www.example.com' } },
+    applicationInstance: {},
     settings: {
       lti_key: 'lti-key',
       user_canvas_domains: [''],

--- a/client/js/_admin/components/application_instances/modal.jsx
+++ b/client/js/_admin/components/application_instances/modal.jsx
@@ -76,6 +76,7 @@ export default class Modal extends React.Component {
       title = 'Update';
       siteId = this.state.newApplicationInstance.site_id || this.props.applicationInstance.site.id;
     }
+    const isUpdate = this.props.applicationInstance && this.props.applicationInstance.id;
     return (
       <ReactModal
         isOpen={this.props.isOpen}
@@ -95,6 +96,7 @@ export default class Modal extends React.Component {
           site_id={`${siteId}`}
           closeModal={() => this.closeModal()}
           newSite={() => this.newSite()}
+          isUpdate={isUpdate}
         />
         <NewSiteModal
           isOpen={this.state.newSiteModalOpen}

--- a/client/js/_admin/components/application_instances/modal.jsx
+++ b/client/js/_admin/components/application_instances/modal.jsx
@@ -8,18 +8,24 @@ export default class Modal extends React.Component {
     isOpen: React.PropTypes.bool.isRequired,
     closeModal: React.PropTypes.func.isRequired,
     sites: React.PropTypes.shape({}),
-    createApplicationInstance: React.PropTypes.func.isRequired,
+    save: React.PropTypes.func.isRequired,
+    applicationInstance: React.PropTypes.shape({
+      id: React.PropTypes.number,
+      site: React.PropTypes.shape({
+        id: React.PropTypes.number,
+      })
+    }),
     application: React.PropTypes.shape({
       id: React.PropTypes.number,
     })
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       newSiteModalOpen: false,
       selectedSite: '',
-      newApplicationInstance: {}
+      newApplicationInstance: props.applicationInstance || {}
     };
   }
 
@@ -53,7 +59,7 @@ export default class Modal extends React.Component {
   }
 
   createInstance() {
-    this.props.createApplicationInstance(
+    this.props.save(
       this.props.application.id,
       this.state.newApplicationInstance
     );
@@ -63,7 +69,13 @@ export default class Modal extends React.Component {
   render() {
     const application = this.props.application;
     const applicationName = application ? application.name : 'Application';
-
+    let title = 'New';
+    let siteId;
+    if (this.state.newApplicationInstance.site_id ||
+        (this.props.applicationInstance && this.props.applicationInstance.id)) {
+      title = 'Update';
+      siteId = this.state.newApplicationInstance.site_id || this.props.applicationInstance.site.id;
+    }
     return (
       <ReactModal
         isOpen={this.props.isOpen}
@@ -73,13 +85,14 @@ export default class Modal extends React.Component {
         className={`c-modal c-modal--settings ${this.showInstanceModal()}`}
       >
         <h2 className="c-modal__title">
-          New {applicationName} Instance
+          {title} {applicationName} Instance
         </h2>
         <ApplicationInstanceForm
           {...this.state.newApplicationInstance}
           onChange={(e) => { this.newApplicationInstanceChange(e); }}
           createInstance={() => this.createInstance()}
           sites={this.props.sites}
+          site_id={`${siteId}`}
           closeModal={() => this.closeModal()}
           newSite={() => this.newSite()}
         />

--- a/client/js/_admin/components/application_instances/modal.spec.jsx
+++ b/client/js/_admin/components/application_instances/modal.spec.jsx
@@ -14,7 +14,7 @@ describe('application instance modal', () => {
     isOpen: true,
     closeModal: () => {},
     sites: {},
-    createApplicationInstance: () => {},
+    save: () => {},
     application: {
       id: 1,
       name

--- a/spec/controllers/api/application_instances_controller_spec.rb
+++ b/spec/controllers/api/application_instances_controller_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe Api::ApplicationInstancesController, type: :controller do
       end
     end
 
+    describe "PUT update" do
+      it "Updates the application instance" do
+        put :update,
+            application_id: @application.id,
+            id: @application_instance.id,
+            application_instance: {
+              lti_secret: "12345",
+            },
+            format: :json
+        expect(response).to have_http_status(204)
+      end
+    end
+
     describe "DEL destroy" do
       it "Deletes the application instance" do
         delete :destroy, { application_id: @application.id, id: @application_instance.id, format: :json }

--- a/spec/controllers/api/applications_controller_spec.rb
+++ b/spec/controllers/api/applications_controller_spec.rb
@@ -53,5 +53,17 @@ RSpec.describe Api::ApplicationsController, type: :controller do
         end
       end
     end
+
+    describe "PUT update" do
+      it "Updates the application instance" do
+        put :update,
+            id: @application.id,
+            application: {
+              name: "bfcoder",
+            },
+            format: :json
+        expect(response).to have_http_status(204)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds cog to each app instance row.
Opens modal to edit it.
Canvas Token will be empty as that is a salted field in the database.

![app_instance_edit](https://cloud.githubusercontent.com/assets/1216167/23044938/b129e2ba-f45f-11e6-85d9-223529e5a701.gif)

No longer can edit lti key
![app_instance_edit](https://cloud.githubusercontent.com/assets/1216167/23046339/2a3e68d2-f466-11e6-996f-83d13087a265.gif)

