### PR TITLE
Only show account/course installs where appropriate.

### DIFF
--- a/client/js/_admin/components/lti_installs/install_pane.jsx
+++ b/client/js/_admin/components/lti_installs/install_pane.jsx
@@ -5,12 +5,16 @@ import CourseInstalls from './course_installs';
 import Pagination     from './pagination';
 
 const PAGE_SIZE = 10;
+const ACCOUNT_TYPES = ['basic', 'account_navigation'];
+const COURSE_TYPES = ['basic', 'course_navigation'];
 
 export default class InstallPane extends React.Component {
   static propTypes = {
     courses             : React.PropTypes.arrayOf(React.PropTypes.shape({})).isRequired,
     loadExternalTools   : React.PropTypes.func,
-    applicationInstance : React.PropTypes.shape({}),
+    applicationInstance : React.PropTypes.shape({
+      lti_type: React.PropTypes.string.isRequired,
+    }),
     canvasRequest       : React.PropTypes.func,
     loadingCourses      : React.PropTypes.shape({}),
     account             : React.PropTypes.shape({
@@ -73,42 +77,62 @@ export default class InstallPane extends React.Component {
   render() {
     const searchedCourses = this.searchedCourses();
     const pageCount = _.ceil(searchedCourses.length / PAGE_SIZE);
+    let accountInstall = 'Account install not available for this tool';
+    let courseInstalls = 'Course install not available for this tool';
+    const {
+      applicationInstance,
+    } = this.props;
+
+    if (applicationInstance) {
+      if (_.includes(ACCOUNT_TYPES, applicationInstance.lti_type)) {
+        accountInstall = (
+          <AccountInstall
+            account={this.props.account}
+            accountInstalls={this.props.account ? this.props.account.installCount : null}
+            applicationInstance={applicationInstance}
+            canvasRequest={this.props.canvasRequest}
+          />
+        );
+      }
+      if (_.includes(COURSE_TYPES, applicationInstance.lti_type)) {
+        courseInstalls = (
+          <span>
+            <div className="c-search c-search--small">
+              <input
+                type="text"
+                placeholder="Search..."
+                onChange={e => this.updateSearchPrefix(e.target.value)}
+              />
+              <i className="i-search" />
+            </div>
+            {
+              !_.isEmpty(this.props.loadingCourses) ?
+                <div className="c-modal--error loading">
+                  <div className="c-loading-icon" />
+                </div> : null
+            }
+            <CourseInstalls
+              applicationInstance={applicationInstance}
+              courses={this.pageCourses(searchedCourses)}
+              loadingCourses={this.props.loadingCourses}
+              canvasRequest={this.props.canvasRequest}
+            />
+            <Pagination
+              setPage={change => this.setState({ currentPage: change.selected })}
+              pageCount={pageCount}
+              courses={this.props.courses}
+              pageSize={PAGE_SIZE}
+              loadingCourses={this.props.loadingCourses}
+              currentPage={this.state.currentPage}
+            />
+          </span>
+        );
+      }
+    }
     return (
       <div className="o-right">
-        <AccountInstall
-          account={this.props.account}
-          accountInstalls={this.props.account ? this.props.account.installCount : null}
-          applicationInstance={this.props.applicationInstance}
-          canvasRequest={this.props.canvasRequest}
-        />
-        <div className="c-search c-search--small">
-          <input
-            type="text"
-            placeholder="Search..."
-            onChange={e => this.updateSearchPrefix(e.target.value)}
-          />
-          <i className="i-search" />
-        </div>
-        {
-          !_.isEmpty(this.props.loadingCourses) ?
-            <div className="c-modal--error loading">
-              <div className="c-loading-icon" />
-            </div> : null
-        }
-        <CourseInstalls
-          applicationInstance={this.props.applicationInstance}
-          courses={this.pageCourses(searchedCourses)}
-          loadingCourses={this.props.loadingCourses}
-          canvasRequest={this.props.canvasRequest}
-        />
-        <Pagination
-          setPage={change => this.setState({ currentPage: change.selected })}
-          pageCount={pageCount}
-          courses={this.props.courses}
-          pageSize={PAGE_SIZE}
-          loadingCourses={this.props.loadingCourses}
-          currentPage={this.state.currentPage}
-        />
+        {accountInstall}
+        {courseInstalls}
       </div>
     );
   }

--- a/client/js/_admin/components/lti_installs/install_pane.spec.jsx
+++ b/client/js/_admin/components/lti_installs/install_pane.spec.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Stub from '../../../../specs_support/stub';
+import InstallPane from './install_pane';
+
+describe('install pane', () => {
+  let result;
+
+  const props = {
+    canvasRequest: () => {},
+    loadingCourses: {},
+    applicationInstance: {},
+    courses: [],
+    account: {
+      installCount: 0,
+    },
+    loadExternalTools: () => {},
+  };
+
+  describe('basic instances', () => {
+    beforeEach(() => {
+      props.applicationInstance.lti_type = 'basic';
+      result = TestUtils.renderIntoDocument(
+        <Stub>
+          <InstallPane {...props} />
+        </Stub>
+      );
+    });
+
+    it('renders the install pane with account installs for basic', () => {
+      const button = TestUtils.findRenderedDOMComponentWithTag(result, 'button');
+      expect(button.textContent).toContain('at Account Level');
+    });
+
+    it('renders the install pane with course installs for basic', () => {
+      const input = TestUtils.findRenderedDOMComponentWithTag(result, 'input');
+      expect(input.placeholder).toContain('Search...');
+    });
+  });
+
+  describe('account_navigation instances', () => {
+    beforeEach(() => {
+      props.applicationInstance.lti_type = 'account_navigation';
+      result = TestUtils.renderIntoDocument(
+        <Stub>
+          <InstallPane {...props} />
+        </Stub>
+      );
+    });
+
+    it('renders the install pane with account installs for basic', () => {
+      const button = TestUtils.findRenderedDOMComponentWithTag(result, 'button');
+      expect(button.textContent).toContain('at Account Level');
+    });
+
+    it('renders the install pane without course installs for account_navigation', () => {
+      const input = TestUtils.scryRenderedDOMComponentsWithTag(result, 'input');
+      expect(input.length).toBe(0);
+    });
+
+  });
+
+  describe('course_navigation instances', () => {
+    beforeEach(() => {
+      props.applicationInstance.lti_type = 'course_navigation';
+      result = TestUtils.renderIntoDocument(
+        <Stub>
+          <InstallPane {...props} />
+        </Stub>
+      );
+    });
+
+    it('renders the install pane with course installs for course_navigation', () => {
+      const input = TestUtils.findRenderedDOMComponentWithTag(result, 'input');
+      expect(input.placeholder).toContain('Search...');
+    });
+
+    it('renders the install pane without account installs for course_navigation', () => {
+      const button = TestUtils.scryRenderedDOMComponentsWithTag(result, 'button');
+      expect(button.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Only show account installs for basic/account_navigation types.
Only show course installs for basic/course_navigation types.
Add specs for install pane.

Will need additional designs if more than this is desired.

![tool_type_ui](https://cloud.githubusercontent.com/assets/1216167/23186208/898b31d6-f843-11e6-9b6a-1e1977dfd40e.gif)

With default message for account navigation tools
![image](https://cloud.githubusercontent.com/assets/1216167/23186923/1d534622-f846-11e6-89d6-928f984032b8.png)

With default message for course navigation tools
![image](https://cloud.githubusercontent.com/assets/1216167/23186942/30fabfd4-f846-11e6-9229-92218532d997.png)
