### PR TITLE
Fix creating tenants from application instances

### DIFF
--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -47,7 +47,7 @@ Apartment.configure do |config|
   #   end
   # end
   #
-  config.tenant_names = lambda { ApplicationInstance.pluck(:lti_key) }
+  config.tenant_names = lambda { ApplicationInstance.distinct.pluck(:tenant) }
 
   #
   # ==> PostgreSQL only options

--- a/spec/models/application_instance_spec.rb
+++ b/spec/models/application_instance_spec.rb
@@ -67,15 +67,6 @@ RSpec.describe ApplicationInstance, type: :model do
       end
     end
 
-    it "deletes a schema upon deletion" do
-      TestAfterCommit.with_commits(true) do
-        expect(Apartment::Tenant).to receive(:create)
-        expect(Apartment::Tenant).to receive(:drop)
-        application_instance = create :application_instance
-        application_instance.destroy
-      end
-    end
-
     it "does not allow the name to be changed after creation" do
       @application_instance = FactoryGirl.create(:application_instance)
       @application_instance.lti_key = "new-lti-key"


### PR DESCRIPTION
This fixes running `rake db:setup` multiple times.
On subsequent runnings of `rake db:setup` the tenants will not
be deleted and thus it causes errors when trying to create
a tenant that already exists.

* Process after_commit to ensure the model is persisted before attempting to create the tenant schema.
* Refactored `.try` to use new short notation of `&.`
* Refactored creating lti_secret to use shorthand notation `||=`
* Refactored `create_schema` to rescue `Apartment::TenantExists` and do nothing
* Fix bug where tenants were created using `lti_key` instead of `tenant`
* Refactor `tenant_names` to be uniq now that `tenant` is used to create Tenants
* Remove after_destroy callback to ensure databases aren't destroyed
* Refactor `destroy_schema` to be a private method to ensure it doesn't accidentally get called from the command line.