### PR TITLE
Load external tools reliably for courses

### DIFF
--- a/client/js/_admin/components/lti_installs/install_pane.jsx
+++ b/client/js/_admin/components/lti_installs/install_pane.jsx
@@ -37,7 +37,7 @@ export default class InstallPane extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if ((prevState.currentPage !== this.state.currentPage) ||
-       (_.isEmpty(prevProps.courses) && !_.isEmpty(this.props.courses)) ||
+       (prevProps.courses.length !== this.props.courses.length) ||
        (prevState.searchPrefix !== this.state.searchPrefix)
     ) {
       this.loadExternalTools();


### PR DESCRIPTION
Previously, they were only loaded one time for a given set of courses.
But if more courses were loaded into the page later, their external tools were never loaded.
This ensures that all courses on the page will have external tools loaded.