### PR TITLE
Pass domain to attempt unique email address

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -40,8 +40,9 @@ module Concerns
       user = User.find_by(lti_provider: lti_provider, lti_user_id: lti_user_id)
 
       if user.blank?
+        domain = params["custom_canvas_api_domain"] || Rails.application.secrets.application_url
         user = _generate_new_lti_user(params)
-        _attempt_uniq_email(user)
+        _attempt_uniq_email(user, domain)
       end
 
       user
@@ -67,7 +68,7 @@ module Concerns
       end
     end
 
-    def _attempt_uniq_email(user)
+    def _attempt_uniq_email(user, domain)
       count = 0 # don't go infinite
       while !safe_save_email(user) && count < 10
         user.email = generate_email(domain)

--- a/spec/controllers/concerns/lti_support_spec.rb
+++ b/spec/controllers/concerns/lti_support_spec.rb
@@ -26,6 +26,10 @@ describe ApplicationController, type: :controller do
 
     context "valid LTI request" do
       it "sets up the user, logs them in and renders the lti launch page" do
+        # Create a user with the same email as for this spec thus forcing
+        # a generated email to happen for the new lti user.
+        FactoryGirl.create(:user, email: "steve@apple.com")
+
         params = lti_params(@app.lti_key, @app.lti_secret, { "launch_url" => @launch_url, "roles" => "Learner" })
         post :index, params
         expect(response).to have_http_status(200)


### PR DESCRIPTION
This fixes a situation where an lti user is attempted to be created with the same email as an existing user in the database. `domain` is now passed in to the generate unique email address method.