### PR TITLE
Add configs to application and application_instance

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -22,12 +22,14 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
   def create
     @application_instance.domain =
       "#{@application_instance.lti_key}.#{ENV['APP_URL']}"
+    @application_instance.config = params[:application_instance][:config]
 
     @application_instance.save!
     render json: @application_instance.as_json(include: :site)
   end
 
   def update
+    @application_instance.config = params[:application_instance][:config]
     @application_instance.update(application_instance_params)
     render json: @application_instance.as_json(include: :site)
   end

--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -22,6 +22,10 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
   def create
     @application_instance.domain =
       "#{@application_instance.lti_key}.#{ENV['APP_URL']}"
+
+    # Strong params doesn't allow arbitrary json to be permitted
+    # So we have to explicitly set the config
+    # This will be allowed in rails 5.1
     @application_instance.config = params[:application_instance][:config]
 
     @application_instance.save!
@@ -29,6 +33,9 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
   end
 
   def update
+    # Strong params doesn't allow arbitrary json to be permitted
+    # So we have to explicitly set the config
+    # This will be allowed in rails 5.1
     @application_instance.config = params[:application_instance][:config]
     @application_instance.update(application_instance_params)
     render json: @application_instance.as_json(include: :site)

--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -7,6 +7,9 @@ class Api::ApplicationsController < Api::ApiApplicationController
   end
 
   def update
+    # Strong params doesn't allow arbitrary json to be permitted
+    # So we have to explicitly set the default_config
+    # This will be allowed in rails 5.1
     @application.default_config = params[:application][:default_config]
     @application.update(application_params)
     respond_with(@application)

--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -7,6 +7,7 @@ class Api::ApplicationsController < Api::ApiApplicationController
   end
 
   def update
+    @application.default_config = params[:application][:default_config]
     @application.update(application_params)
     respond_with(@application)
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,7 +1,11 @@
 class Application < ActiveRecord::Base
+  serialize :default_config, HashSerializer
 
   has_many :application_instances
   validates :name, presence: true, uniqueness: true
+
+  # example store_accessor for default_config
+  store_accessor :default_config, :foo
 
   enum kind: [:lti, :admin]
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,7 +5,10 @@ class Application < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 
   # example store_accessor for default_config
-  store_accessor :default_config, :foo
+  # This allows access to instance.default_config[:foo] like instance.foo
+  # Or instance.bar
+  # If foo is not set in the default_config json, it will return nil
+  # store_accessor :default_config, :foo, :bar
 
   enum kind: [:lti, :admin]
 end

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -14,7 +14,10 @@ class ApplicationInstance < ActiveRecord::Base
   end
 
   # example store_accessor for config
-  store_accessor :config, :foo
+  # This allows access to instance.config[:foo] like instance.foo
+  # Or instance.bar
+  # If foo is not set in the config json, it will return nil
+  # store_accessor :config, :foo, :bar
 
   enum lti_type: [:basic, :course_navigation, :account_navigation]
 

--- a/app/serializers/hash_serializer.rb
+++ b/app/serializers/hash_serializer.rb
@@ -1,0 +1,9 @@
+class HashSerializer
+  def self.dump(hash)
+    hash.to_json
+  end
+
+  def self.load(hash)
+    (hash || {}).with_indifferent_access
+  end
+end

--- a/client/js/_admin/actions/application_instances.js
+++ b/client/js/_admin/actions/application_instances.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import wrapper from '../../constants/wrapper';
 import Network from '../../constants/network';
 
@@ -32,23 +33,27 @@ export function getApplicationInstance(applicationId, applicationInstanceId) {
 }
 
 export function createApplicationInstance(applicationId, applicationInstance) {
+  const appInstanceClone = _.cloneDeep(applicationInstance);
+  appInstanceClone.config = JSON.parse(applicationInstance.config || '{}');
   return {
     type   : Constants.CREATE_APPLICATION_INSTANCE,
     method : Network.POST,
     url    : `/api/applications/${applicationId}/application_instances`,
     body   : {
-      application_instance: applicationInstance,
+      application_instance: appInstanceClone,
     }
   };
 }
 
 export function saveApplicationInstance(applicationId, applicationInstance) {
+  const appInstanceClone = _.cloneDeep(applicationInstance);
+  appInstanceClone.config = JSON.parse(applicationInstance.config || '{}');
   return {
     type: Constants.SAVE_APPLICATION_INSTANCE,
     method: Network.PUT,
     url: `/api/applications/${applicationId}/application_instances/${applicationInstance.id}`,
     body: {
-      application_instance: applicationInstance,
+      application_instance: appInstanceClone,
     }
   };
 }

--- a/client/js/_admin/actions/applications.js
+++ b/client/js/_admin/actions/applications.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import wrapper from '../../constants/wrapper';
 import Network from '../../constants/network';
 
@@ -21,12 +22,14 @@ export function getApplications() {
 }
 
 export function saveApplication(application) {
+  const applicationClone = _.cloneDeep(application);
+  applicationClone.default_config = JSON.parse(application.default_config || '{}');
   return {
     type   : Constants.SAVE_APPLICATION,
     method : Network.PUT,
     url    : `api/applications/${application.id}`,
     body   : {
-      application
+      application: applicationClone
     }
   };
 }

--- a/client/js/_admin/components/application_instances/form.jsx
+++ b/client/js/_admin/components/application_instances/form.jsx
@@ -3,6 +3,7 @@ import _           from 'lodash';
 import ReactSelect from 'react-select';
 import Input       from '../common/input';
 import Textarea from '../common/textarea';
+import Warning from '../common/warning';
 
 export const TEXT_FIELDS = {
   lti_key      : 'LTI Key',
@@ -27,6 +28,7 @@ export default class Form extends React.Component {
     sites:      React.PropTypes.shape({}),
     isUpdate:   React.PropTypes.bool,
     config: React.PropTypes.string,
+    configParseError: React.PropTypes.string,
   };
 
   selectSite(option) {
@@ -83,6 +85,13 @@ export default class Form extends React.Component {
       onSelect: () => this.props.newSite()
     });
 
+    let erroneousConfigWarning = null;
+    if (this.props.configParseError) {
+      erroneousConfigWarning = (
+        <Warning text={this.props.configParseError} />
+      );
+    }
+
     return (
       <form>
         <div className="o-grid o-grid__modal-top">
@@ -110,7 +119,7 @@ export default class Form extends React.Component {
             <Textarea
               className="c-input"
               labelText="Config"
-              inputProps={{
+              textareaProps={{
                 id: 'application_instance_config',
                 name: 'config',
                 placeholder: 'ex: { "foo": "bar" }',
@@ -118,6 +127,7 @@ export default class Form extends React.Component {
                 value: this.props.config || '',
                 onChange: this.props.onChange,
               }}
+              warning={erroneousConfigWarning}
             />
           </div>
         </div>

--- a/client/js/_admin/components/application_instances/form.jsx
+++ b/client/js/_admin/components/application_instances/form.jsx
@@ -2,6 +2,7 @@ import React       from 'react';
 import _           from 'lodash';
 import ReactSelect from 'react-select';
 import Input       from '../common/input';
+import Textarea from '../common/textarea';
 
 export const TEXT_FIELDS = {
   lti_key      : 'LTI Key',
@@ -25,6 +26,7 @@ export default class Form extends React.Component {
     site_id:    React.PropTypes.string,
     sites:      React.PropTypes.shape({}),
     isUpdate:   React.PropTypes.bool,
+    config: React.PropTypes.string,
   };
 
   selectSite(option) {
@@ -104,6 +106,20 @@ export default class Form extends React.Component {
               this.renderInput('o-grid__item u-half', 'c-input', 'text', undefined, this.props.isUpdate, ...args)
             )
           }
+          <div className="o-grid__item u-full">
+            <Textarea
+              className="c-input"
+              labelText="Config"
+              inputProps={{
+                id: 'application_instance_config',
+                name: 'config',
+                placeholder: 'ex: { "foo": "bar" }',
+                rows: 3,
+                value: this.props.config || '',
+                onChange: this.props.onChange,
+              }}
+            />
+          </div>
         </div>
         <h3 className="c-modal__subtitle">Install Settings</h3>
         <div className="o-grid o-grid__bottom">

--- a/client/js/_admin/components/application_instances/form.spec.jsx
+++ b/client/js/_admin/components/application_instances/form.spec.jsx
@@ -18,6 +18,7 @@ describe('application instance form', () => {
       newSite:        () => {},
       site_id:        'foo',
       sites:          {},
+      config: '{ "foo": "bar" }',
     };
     result = TestUtils.renderIntoDocument(
       <Form {...props} />
@@ -60,6 +61,13 @@ describe('application instance form', () => {
       TestUtils.Simulate.click(modalButton);
       expect(modalClosed).toBe(true);
     });
+  });
+
+  it('renders config', () => {
+    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(result, 'textarea');
+    const input = _.find(inputs, { id: 'application_instance_config' });
+    expect(input).toBeDefined();
+    expect(input.value).toBe('{ "foo": "bar" }');
   });
 
 });

--- a/client/js/_admin/components/application_instances/modal.jsx
+++ b/client/js/_admin/components/application_instances/modal.jsx
@@ -11,6 +11,7 @@ export default class Modal extends React.Component {
     save: React.PropTypes.func.isRequired,
     applicationInstance: React.PropTypes.shape({
       id: React.PropTypes.number,
+      config: React.PropTypes.string,
       site: React.PropTypes.shape({
         id: React.PropTypes.number,
       })

--- a/client/js/_admin/components/application_instances/modal.jsx
+++ b/client/js/_admin/components/application_instances/modal.jsx
@@ -50,11 +50,21 @@ export default class Modal extends React.Component {
   }
 
   newApplicationInstanceChange(e) {
+    let configParseError = null;
+    if (e.target.name === 'config') {
+      try {
+        JSON.parse(e.target.value || '{}');
+      } catch (err) {
+        configParseError = err.toString();
+      }
+    }
+
     this.setState({
       newApplicationInstance: {
         ...this.state.newApplicationInstance,
         [e.target.name]: e.target.value
-      }
+      },
+      configParseError,
     });
   }
 
@@ -91,6 +101,7 @@ export default class Modal extends React.Component {
         </h2>
         <ApplicationInstanceForm
           {...this.state.newApplicationInstance}
+          configParseError={this.state.configParseError}
           onChange={(e) => { this.newApplicationInstanceChange(e); }}
           save={() => this.save()}
           sites={this.props.sites}

--- a/client/js/_admin/components/applications/form.jsx
+++ b/client/js/_admin/components/applications/form.jsx
@@ -1,4 +1,5 @@
 import React       from 'react';
+import Textarea from '../common/textarea';
 
 export default function Form(props) {
 
@@ -22,6 +23,20 @@ export default function Form(props) {
             <span>Canvas API Permissions</span>
           </label>
         </div>
+        <div className="o-grid__item u-full">
+          <Textarea
+            className="c-input"
+            labelText="Default Config"
+            inputProps={{
+              id: 'application_default_config',
+              name: 'default_config',
+              placeholder: 'ex: { "foo": "bar" }',
+              rows: 3,
+              value: props.default_config || '',
+              onChange: props.onChange,
+            }}
+          />
+        </div>
       </div>
       <button
         type="button"
@@ -43,7 +58,8 @@ export default function Form(props) {
 }
 
 Form.propTypes = {
-  onChange       : React.PropTypes.func.isRequired,
-  closeModal     : React.PropTypes.func.isRequired,
-  description    : React.PropTypes.string
+  onChange: React.PropTypes.func.isRequired,
+  closeModal: React.PropTypes.func.isRequired,
+  description: React.PropTypes.string,
+  default_config: React.PropTypes.string,
 };

--- a/client/js/_admin/components/applications/form.jsx
+++ b/client/js/_admin/components/applications/form.jsx
@@ -1,7 +1,14 @@
-import React       from 'react';
+import React from 'react';
 import Textarea from '../common/textarea';
+import Warning from '../common/warning';
 
 export default function Form(props) {
+  let erroneousConfigWarning = null;
+  if (props.configParseError) {
+    erroneousConfigWarning = (
+      <Warning text={props.configParseError} />
+    );
+  }
 
   return (
     <form>
@@ -27,14 +34,15 @@ export default function Form(props) {
           <Textarea
             className="c-input"
             labelText="Default Config"
-            inputProps={{
+            textareaProps={{
               id: 'application_default_config',
               name: 'default_config',
               placeholder: 'ex: { "foo": "bar" }',
               rows: 3,
-              value: props.default_config || '',
+              value: props.defaultConfig || '',
               onChange: props.onChange,
             }}
+            warning={erroneousConfigWarning}
           />
         </div>
       </div>
@@ -61,5 +69,6 @@ Form.propTypes = {
   onChange: React.PropTypes.func.isRequired,
   closeModal: React.PropTypes.func.isRequired,
   description: React.PropTypes.string,
-  default_config: React.PropTypes.string,
+  defaultConfig: React.PropTypes.string,
+  configParseError: React.PropTypes.string,
 };

--- a/client/js/_admin/components/applications/form.spec.jsx
+++ b/client/js/_admin/components/applications/form.spec.jsx
@@ -1,5 +1,6 @@
 import React        from 'react';
 import TestUtils    from 'react-addons-test-utils';
+import _ from 'lodash';
 import Stub         from '../../../../specs_support/stub';
 import Form         from './form';
 
@@ -17,7 +18,8 @@ describe('applications form', () => {
       onChange    : () => {},
       closeModal  : () => { didClose = true; },
       save        : () => { didSave = true; },
-      description : 'SPEC_DESCRIPTION'
+      description : 'SPEC_DESCRIPTION',
+      default_config: '{ "foo": "bar" }',
     };
 
     result = TestUtils.renderIntoDocument(
@@ -45,5 +47,12 @@ describe('applications form', () => {
     const childDivs = element.childNodes;
     const inputTag = childDivs[0].firstChild.childNodes[1];
     expect(inputTag.value).toContain('SPEC_DESCRIPTION');
+  });
+
+  it('renders default config', () => {
+    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(result, 'textarea');
+    const input = _.find(inputs, { id: 'application_default_config' });
+    expect(input).toBeDefined();
+    expect(input.value).toBe('{ "foo": "bar" }');
   });
 });

--- a/client/js/_admin/components/applications/form.spec.jsx
+++ b/client/js/_admin/components/applications/form.spec.jsx
@@ -19,7 +19,7 @@ describe('applications form', () => {
       closeModal  : () => { didClose = true; },
       save        : () => { didSave = true; },
       description : 'SPEC_DESCRIPTION',
-      default_config: '{ "foo": "bar" }',
+      defaultConfig: '{ "foo": "bar" }',
     };
 
     result = TestUtils.renderIntoDocument(

--- a/client/js/_admin/components/applications/modal.jsx
+++ b/client/js/_admin/components/applications/modal.jsx
@@ -18,16 +18,26 @@ export default class Modal extends React.Component {
   constructor(props) {
     super();
     this.state = {
-      application: { ...props.application }
+      application: { ...props.application },
+      configParseError: null,
     };
   }
 
   applicationChange(e) {
+    let configParseError = null;
+    if (e.target.name === 'default_config') {
+      try {
+        JSON.parse(e.target.value || '{}');
+      } catch (err) {
+        configParseError = err.toString();
+      }
+    }
     this.setState({
       application: {
         ...this.state.application,
-        [e.target.name]: e.target.value
-      }
+        [e.target.name]: e.target.value,
+      },
+      configParseError,
     });
   }
 
@@ -48,7 +58,8 @@ export default class Modal extends React.Component {
         <h2 className="c-modal__title">{this.state.application.name} Settings</h2>
         <Form
           description={this.state.application.description}
-          default_config={this.state.application.default_config}
+          defaultConfig={this.state.application.default_config}
+          configParseError={this.state.configParseError}
           onChange={(e) => { this.applicationChange(e); }}
           closeModal={() => this.props.closeModal()}
           save={() => this.saveApplication()}

--- a/client/js/_admin/components/applications/modal.jsx
+++ b/client/js/_admin/components/applications/modal.jsx
@@ -8,6 +8,7 @@ export default class Modal extends React.Component {
     application: React.PropTypes.shape({
       name: React.PropTypes.string,
       description: React.PropTypes.string,
+      default_config: React.PropTypes.string,
     }),
     isOpen: React.PropTypes.bool.isRequired,
     closeModal: React.PropTypes.func.isRequired,
@@ -47,6 +48,7 @@ export default class Modal extends React.Component {
         <h2 className="c-modal__title">{this.state.application.name} Settings</h2>
         <Form
           description={this.state.application.description}
+          default_config={this.state.application.default_config}
           onChange={(e) => { this.applicationChange(e); }}
           closeModal={() => this.props.closeModal()}
           save={() => this.saveApplication()}

--- a/client/js/_admin/components/common/textarea.jsx
+++ b/client/js/_admin/components/common/textarea.jsx
@@ -1,0 +1,27 @@
+import React       from 'react';
+
+export default function Input(props) {
+  return (
+    <label htmlFor={props.inputProps.id} className={props.className}>
+      <span>{props.labelText}</span>
+      <textarea {...props.inputProps} />
+    </label>
+  );
+}
+
+Input.propTypes = {
+  labelText: React.PropTypes.string,
+  inputProps: React.PropTypes.shape({
+    id: React.PropTypes.string,
+    value: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    name: React.PropTypes.string,
+    placeholder: React.PropTypes.string,
+    maxlength: React.PropTypes.number,
+    minlength: React.PropTypes.number,
+    cols: React.PropTypes.number,
+    rows: React.PropTypes.number,
+    onChange: React.PropTypes.func,
+  }),
+  className: React.PropTypes.string,
+};

--- a/client/js/_admin/components/common/textarea.jsx
+++ b/client/js/_admin/components/common/textarea.jsx
@@ -1,27 +1,40 @@
-import React       from 'react';
+import React from 'react';
 
-export default function Input(props) {
+export default function Textarea(props) {
   return (
-    <label htmlFor={props.inputProps.id} className={props.className}>
+    <label htmlFor={props.textareaProps.id} className={props.className}>
       <span>{props.labelText}</span>
-      <textarea {...props.inputProps} />
+      <textarea
+        id={props.textareaProps.id}
+        value={props.textareaProps.value}
+        disabled={props.textareaProps.disabled}
+        name={props.textareaProps.name}
+        placeholder={props.textareaProps.placeholder}
+        maxLength={props.textareaProps.maxLength}
+        minLength={props.textareaProps.minLength}
+        cols={props.textareaProps.cols}
+        rows={props.textareaProps.rows}
+        onChange={props.textareaProps.onChange}
+      />
+      {props.warning}
     </label>
   );
 }
 
-Input.propTypes = {
+Textarea.propTypes = {
   labelText: React.PropTypes.string,
-  inputProps: React.PropTypes.shape({
+  textareaProps: React.PropTypes.shape({
     id: React.PropTypes.string,
     value: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     name: React.PropTypes.string,
     placeholder: React.PropTypes.string,
-    maxlength: React.PropTypes.number,
-    minlength: React.PropTypes.number,
+    maxLength: React.PropTypes.number,
+    minLength: React.PropTypes.number,
     cols: React.PropTypes.number,
     rows: React.PropTypes.number,
     onChange: React.PropTypes.func,
   }),
+  warning: React.PropTypes.shape({}),
   className: React.PropTypes.string,
 };

--- a/client/js/_admin/components/common/textarea.spec.jsx
+++ b/client/js/_admin/components/common/textarea.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Stub from '../../../../specs_support/stub';
+import Textarea from './textarea';
+
+describe('textarea', () => {
+
+  let result;
+  const props = {
+    inputProps: {
+      id: 'IM AN ID',
+      value: 'IM A VALUE',
+      name: 'the name',
+      onChange: () => {},
+    },
+    className: 'imaclass',
+    labelText: 'IMA LABEL',
+  };
+
+  describe('textarea', () => {
+
+    beforeEach(() => {
+      result = TestUtils.renderIntoDocument(
+        <Stub>
+          <Textarea {...props} />
+        </Stub>
+      );
+    });
+
+    it('renders the textarea with the correct attributes', () => {
+      const textarea = TestUtils.findRenderedDOMComponentWithTag(result, 'textarea');
+      expect(textarea.getAttribute('id')).toBe('IM AN ID');
+    });
+
+    it('renders text before the text textarea', () => {
+      const label = TestUtils.findRenderedDOMComponentWithTag(result, 'label');
+      expect(label.children[0].textContent).toBe('IMA LABEL');
+    });
+
+  });
+});

--- a/client/js/_admin/components/common/textarea.spec.jsx
+++ b/client/js/_admin/components/common/textarea.spec.jsx
@@ -7,7 +7,7 @@ describe('textarea', () => {
 
   let result;
   const props = {
-    inputProps: {
+    textareaProps: {
       id: 'IM AN ID',
       value: 'IM A VALUE',
       name: 'the name',
@@ -17,25 +17,22 @@ describe('textarea', () => {
     labelText: 'IMA LABEL',
   };
 
-  describe('textarea', () => {
-
-    beforeEach(() => {
-      result = TestUtils.renderIntoDocument(
-        <Stub>
-          <Textarea {...props} />
-        </Stub>
-      );
-    });
-
-    it('renders the textarea with the correct attributes', () => {
-      const textarea = TestUtils.findRenderedDOMComponentWithTag(result, 'textarea');
-      expect(textarea.getAttribute('id')).toBe('IM AN ID');
-    });
-
-    it('renders text before the text textarea', () => {
-      const label = TestUtils.findRenderedDOMComponentWithTag(result, 'label');
-      expect(label.children[0].textContent).toBe('IMA LABEL');
-    });
-
+  beforeEach(() => {
+    result = TestUtils.renderIntoDocument(
+      <Stub>
+        <Textarea {...props} />
+      </Stub>
+    );
   });
+
+  it('renders the textarea with the correct attributes', () => {
+    const textarea = TestUtils.findRenderedDOMComponentWithTag(result, 'textarea');
+    expect(textarea.getAttribute('id')).toBe('IM AN ID');
+  });
+
+  it('renders text before the text textarea', () => {
+    const label = TestUtils.findRenderedDOMComponentWithTag(result, 'label');
+    expect(label.children[0].textContent).toBe('IMA LABEL');
+  });
+
 });

--- a/client/js/_admin/components/common/warning.jsx
+++ b/client/js/_admin/components/common/warning.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function Warning(props) {
+  const styles = {
+    warning: {
+      color: 'red',
+    },
+  };
+
+  return (
+    <div style={styles.warning}>
+      Warning! Bad JSON! {props.text}
+    </div>
+  );
+}
+
+Warning.propTypes = {
+  text: React.PropTypes.string,
+};

--- a/client/js/_admin/components/common/warning.spec.jsx
+++ b/client/js/_admin/components/common/warning.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Stub from '../../../../specs_support/stub';
+import Warning from './warning';
+
+describe('warning', () => {
+
+  let result;
+  const props = {
+    text: 'bfcoder was here',
+  };
+
+  beforeEach(() => {
+    result = TestUtils.renderIntoDocument(
+      <Stub>
+        <Warning {...props} />
+      </Stub>
+    );
+  });
+
+  it('renders the warning', () => {
+    const warning = TestUtils.scryRenderedDOMComponentsWithTag(result, 'div');
+    expect(warning[0].textContent).toContain('bfcoder was here');
+  });
+});

--- a/client/js/_admin/reducers/application_instances.js
+++ b/client/js/_admin/reducers/application_instances.js
@@ -9,21 +9,20 @@ export default function instances(state = initialState, action) {
     case ApplicationInstancesConstants.GET_APPLICATION_INSTANCES_DONE: {
       const newState = _.cloneDeep(state);
       _.forEach(action.payload, (instance) => {
-        newState[instance.id] = instance;
+        const instanceClone = _.cloneDeep(instance);
+        instanceClone.config = JSON.stringify(instance.config);
+        newState[instance.id] = instanceClone;
       });
       return newState;
     }
 
-    case ApplicationInstancesConstants.GET_APPLICATION_INSTANCE_DONE: {
-      const newState = _.cloneDeep(state);
-      newState[action.payload.id] = action.payload;
-      return newState;
-    }
-
+    case ApplicationInstancesConstants.GET_APPLICATION_INSTANCE_DONE:
     case ApplicationInstancesConstants.SAVE_APPLICATION_INSTANCE_DONE:
     case ApplicationInstancesConstants.CREATE_APPLICATION_INSTANCE_DONE: {
       const newState = _.cloneDeep(state);
-      newState[action.payload.id] = action.payload;
+      const instanceClone = _.cloneDeep(action.payload);
+      instanceClone.config = JSON.stringify(action.payload.config);
+      newState[action.payload.id] = instanceClone;
       return newState;
     }
 

--- a/client/js/_admin/reducers/applications.js
+++ b/client/js/_admin/reducers/applications.js
@@ -9,7 +9,9 @@ export default (state = initialState, action) => {
     case Constants.GET_APPLICATIONS_DONE: {
       const newState = _.cloneDeep(state);
       _.forEach(action.payload, (app) => {
-        newState[app.id] = app;
+        const appClone = _.cloneDeep(app);
+        appClone.default_config = JSON.stringify(app.default_config);
+        newState[app.id] = appClone;
       });
       return newState;
     }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: "localhost" }
+
+  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/db/migrate/20170309132554_add_default_config_to_application.rb
+++ b/db/migrate/20170309132554_add_default_config_to_application.rb
@@ -1,0 +1,6 @@
+class AddDefaultConfigToApplication < ActiveRecord::Migration
+  def change
+    add_column :applications, :default_config, :jsonb, default: '{}'
+    add_column :application_instances, :config, :jsonb, default: '{}'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170206172615) do
+ActiveRecord::Schema.define(version: 20170309132554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,11 +24,12 @@ ActiveRecord::Schema.define(version: 20170206172615) do
     t.string   "encrypted_canvas_token"
     t.string   "encrypted_canvas_token_salt"
     t.string   "encrypted_canvas_token_iv"
-    t.datetime "created_at",                                           null: false
-    t.datetime "updated_at",                                           null: false
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
     t.string   "domain",                      limit: 2048
     t.integer  "site_id"
     t.string   "tenant"
+    t.jsonb    "config",                                   default: {}
   end
 
   add_index "application_instances", ["application_id"], name: "index_application_instances_on_application_id", using: :btree
@@ -38,11 +39,12 @@ ActiveRecord::Schema.define(version: 20170206172615) do
     t.string   "name"
     t.string   "description"
     t.string   "client_application_name"
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.text     "canvas_api_permissions"
     t.integer  "kind",                        default: 0
     t.integer  "application_instances_count"
+    t.jsonb    "default_config",              default: {}
   end
 
   create_table "authentications", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,6 +31,7 @@ applications = [
     client_application_name: "admin_app",
     canvas_api_permissions: admin_api_permissions,
     kind: Application.kinds[:admin],
+    default_config: { foo: "bar" },
     application_instances: [{
       tenant: "lti-admin",
       lti_key: "lti-admin",
@@ -45,6 +46,7 @@ applications = [
     client_application_name: "app",
     # List Canvas API methods the app is allowed to use. A full list of constants can be found in canvas_urls
     canvas_api_permissions: "LIST_ACCOUNTS",
+    default_config: { foo: "bar" },
     application_instances: [{
       tenant: Rails.application.secrets.default_lti_key,
       lti_key: Rails.application.secrets.default_lti_key,

--- a/spec/models/application_instance_spec.rb
+++ b/spec/models/application_instance_spec.rb
@@ -3,28 +3,29 @@ require "rails_helper"
 RSpec.describe ApplicationInstance, type: :model do
   describe "create application" do
     before :each do
-      @site = FactoryGirl.create(:site)
+      @site = create(:site)
       @name = "test"
-      @application = FactoryGirl.create(:application, name: @name)
+      @application = create(:application, name: @name)
     end
 
     it "sets a default lti key" do
-      @application_instance = described_class.create!(site: @site, application: @application)
+      @application_instance = create(:application_instance, lti_key: nil, site: @site, application: @application)
       expect(@application_instance.lti_key).to eq(@name)
     end
 
     it "sets a default secret" do
-      @application_instance = described_class.create!(site: @site, application: @application)
+      @application_instance = create(:application_instance, site: @site, application: @application)
       expect(@application_instance.lti_secret).to be_present
     end
 
     it "sets a default tenant to the lti_key" do
-      @application_instance = described_class.create!(site: @site, application: @application)
+      @application_instance = create(:application_instance, site: @site, application: @application)
       expect(@application_instance.tenant).to eq(@application_instance.lti_key)
     end
 
     it "doesn't change the tenant" do
-      @application_instance = described_class.create!(
+      @application_instance = create(
+        :application_instance,
         site: @site,
         application: @application,
         tenant: "bfcoder",
@@ -35,28 +36,41 @@ RSpec.describe ApplicationInstance, type: :model do
 
     it "sets a valid lti_key using the name" do
       name = "A Test"
-      application = FactoryGirl.create(:application, name: name)
-      @application_instance = described_class.create!(site: @site, application: application)
+      application = create(:application, name: name)
+      @application_instance = create(:application_instance, lti_key: nil, site: @site, application: application)
       expect(@application_instance.lti_key).to eq("a-test")
     end
 
     it "doesn't set lti_key if the lti_key is already set" do
       lti_key = "the-lti-key"
-      @application_instance = described_class.create!(
+      @application_instance = create(
+        :application_instance,
         site: @site,
         lti_key: lti_key,
       )
       expect(@application_instance.lti_key).to eq(lti_key)
     end
 
+    it "sets the config to the application default_config if blank" do
+      app = create(:application, default_config: { foo: :bar })
+      app_instance = create(:application_instance, application: app)
+      expect(app_instance.config).to eq app.default_config
+    end
+
+    it "keeps the config to as entered" do
+      app = create(:application, default_config: { foo: :bar })
+      app_instance = create(:application_instance, application: app, config: { foo: :baz })
+      expect(app_instance.config).to eq("foo" => "baz")
+    end
+
     it "requires a site" do
       expect do
-        described_class.create!(lti_key: "test")
+        create(:application_instance, site: nil, lti_key: "test")
       end.to raise_exception(ActiveRecord::RecordInvalid)
     end
 
     it "sets the lti_type to basic if no value is set" do
-      @application_instance = described_class.create!(lti_key: "test", site: @site)
+      @application_instance = create(:application_instance, lti_key: "test", site: @site)
       expect(@application_instance.basic?).to be true
     end
 
@@ -68,7 +82,7 @@ RSpec.describe ApplicationInstance, type: :model do
     end
 
     it "does not allow the name to be changed after creation" do
-      @application_instance = FactoryGirl.create(:application_instance)
+      @application_instance = create(:application_instance)
       @application_instance.lti_key = "new-lti-key"
       expect(@application_instance.valid?).to be false
     end


### PR DESCRIPTION
* Add configs to application and application_instance in the database
* Add serializer for configs
  * Can now access model.foo instead of model.config[:foo]
  * Ensure new app instance copies the default config from an app if it is blank
  * Add example to seeds
* Add UI to edit default config for applications
* Add UI to edit config for app instance
* Add/update specs

![app_configs](https://cloud.githubusercontent.com/assets/1216167/23766858/b29c641e-04c3-11e7-92db-39e573cc3893.gif)

![json_error](https://cloud.githubusercontent.com/assets/1216167/23772598/bd9ee9b2-04d8-11e7-88a3-4877d2f97ef3.gif)
