### PR TITLE
Add course links to course install

### DIFF
--- a/client/js/_admin/components/lti_installs/course_install_row.jsx
+++ b/client/js/_admin/components/lti_installs/course_install_row.jsx
@@ -1,48 +1,72 @@
-import React                     from 'react';
+import React from 'react';
 import {
   createExternalToolCourses,
   deleteExternalToolCourses,
 } from '../../../libs/canvas/constants/external_tools';
 
 export default function CourseInstallRow(props) {
+  const {
+    courseName,
+    courseId,
+    installedTool,
+    canvasRequest,
+    applicationInstance,
+  } = props;
+
   function installInCourse() {
-    if (props.installedTool) {
-      props.canvasRequest(
+    if (installedTool) {
+      canvasRequest(
         deleteExternalToolCourses,
-        { course_id: props.courseId, external_tool_id: props.installedTool.id },
+        {
+          course_id: courseId,
+          external_tool_id: installedTool.id,
+        },
         null,
         {
-          courseId: props.courseId,
+          courseId,
         },
       );
     } else {
-      props.canvasRequest(
+      canvasRequest(
         createExternalToolCourses,
-        { course_id: props.courseId },
         {
-          name          : props.applicationInstance.name,
-          consumer_key  : props.applicationInstance.lti_key,
-          shared_secret : props.applicationInstance.lti_secret,
-          privacy_level : 'public',
-          config_type   : 'by_xml',
-          config_xml    : props.applicationInstance.lti_config_xml
+          course_id: courseId,
         },
         {
-          courseId: props.courseId,
+          name: applicationInstance.name,
+          consumer_key: applicationInstance.lti_key,
+          shared_secret: applicationInstance.lti_secret,
+          privacy_level: 'public',
+          config_type: 'by_xml',
+          config_xml: applicationInstance.lti_config_xml
+        },
+        {
+          courseId,
         },
       );
     }
   }
 
-  const installText = props.installedTool ? 'Uninstall' : 'Install';
+  const installText = installedTool ? 'Uninstall' : 'Install';
+
+  let courseUrl = `${applicationInstance.site.url}/courses/${courseId}`;
+  if (installedTool) {
+    courseUrl = `${courseUrl}/external_tools/${installedTool.id}`;
+  }
 
   return (
     <tr>
-      <td><div className="c-table--inactive">{props.courseName}</div></td>
+      <td>
+        <div className="c-table--inactive">
+          <a href={courseUrl} target="_blank" rel="noopener noreferrer">
+            {courseName}
+          </a>
+        </div>
+      </td>
       <td>
         <button
           className="c-btn c-btn--gray"
-          onClick={() => installInCourse(props.installedTool, props.courseId)}
+          onClick={() => installInCourse(installedTool, courseId)}
         >
           {installText}
         </button>
@@ -52,9 +76,14 @@ export default function CourseInstallRow(props) {
 }
 
 CourseInstallRow.propTypes = {
-  courseName          : React.PropTypes.string.isRequired,
-  // canvasRequest       : React.PropTypes.func.isRequired,
-  courseId            : React.PropTypes.number.isRequired,
-  installedTool       : React.PropTypes.shape({}),
-  // applicationInstance : React.PropTypes.shape({}),
+  courseName: React.PropTypes.string.isRequired,
+  canvasRequest: React.PropTypes.func.isRequired,
+  courseId: React.PropTypes.number.isRequired,
+  installedTool: React.PropTypes.shape({}),
+  applicationInstance: React.PropTypes.shape({
+    name: React.PropTypes.string,
+    lti_key: React.PropTypes.string,
+    lti_secret: React.PropTypes.string,
+    lti_config_xml: React.PropTypes.string,
+  }),
 };

--- a/client/js/_admin/components/lti_installs/course_install_row.spec.jsx
+++ b/client/js/_admin/components/lti_installs/course_install_row.spec.jsx
@@ -1,6 +1,7 @@
 import React              from 'react';
 import TestUtils          from 'react-addons-test-utils';
 import { Provider }       from 'react-redux';
+import _ from 'lodash';
 import Helper             from '../../../../specs_support/helper';
 import CourseInstallRow   from './course_install_row';
 
@@ -9,6 +10,7 @@ describe('lti installs course install row', () => {
   let result;
   const courseId = 123;
   const courseName = 'courseName';
+  const installedToolId = 12;
 
   const props = {
     applicationInstance: {
@@ -16,9 +18,12 @@ describe('lti installs course install row', () => {
       lti_key: 'lti_key',
       lti_secret: 'lti_secret',
       lti_config_xml: 'lti_config_xml',
+      site: {
+        url: 'example.com'
+      }
     },
     installedTool: {
-      id: 12
+      id: installedToolId,
     },
     canvasRequest: () => {},
     courseName,
@@ -51,6 +56,33 @@ describe('lti installs course install row', () => {
   it('renders buttons', () => {
     const installButton = TestUtils.findRenderedDOMComponentWithTag(result, 'button');
     expect(installButton.textContent).toBe('Uninstall');
+  });
+
+  it('renders link without external tool', () => {
+    const tempProps = _.cloneDeep(props);
+    delete tempProps.installedTool;
+    result = TestUtils.renderIntoDocument(
+      <Provider store={Helper.makeStore()}>
+        <table>
+          <tbody>
+            <CourseInstallRow {...tempProps} />
+          </tbody>
+        </table>
+      </Provider>
+    );
+    const link = TestUtils.findRenderedDOMComponentWithTag(result, 'a');
+    expect(link).toBeDefined();
+    const installLink = `example.com/courses/${props.courseId}`;
+    const found = _.includes(link.href, installLink);
+    expect(found).toBe(true);
+  });
+
+  it('renders link with external tool', () => {
+    const link = TestUtils.findRenderedDOMComponentWithTag(result, 'a');
+    expect(link).toBeDefined();
+    const installLink = `example.com/courses/${props.courseId}/external_tools/${installedToolId}`;
+    const found = _.includes(link.href, installLink);
+    expect(found).toBe(true);
   });
 
 });


### PR DESCRIPTION
Link goes to course in a new tab. If the tool is installed to the course, it takes you to the external tool page. https://www.pivotaltracker.com/story/show/141273415

![course_link](https://cloud.githubusercontent.com/assets/1216167/24872866/1b9b9058-1ddc-11e7-9515-f56810e11c18.gif)
