### PR TITLE
Sekure

### DIFF
--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -37,7 +37,11 @@ module Concerns
       canvas_api_permissions = current_application_instance.
         application.canvas_api_permissions.
         split(",")
-      user_not_authorized unless canvas_api_permissions.include?(params[:type])
+
+      if permission = canvas_api_permissions[params[:type]]
+        return
+      end
+      user_not_authorized
     end
 
     class CanvasApiTokenRequired < LMS::Canvas::CanvasException

--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -34,14 +34,22 @@ module Concerns
     end
 
     def protect_canvas_api
-      canvas_api_permissions = current_application_instance.
-        application.canvas_api_permissions.
-        split(",")
-
-      if permission = canvas_api_permissions[params[:type]]
+      if canvas_api_permissions.has_key?(params[:type]) &&
+          allowed_roles.present? &&
+          (allowed_roles & current_user.roles.map(&:name)).present?
         return
       end
       user_not_authorized
+    end
+
+    def allowed_roles
+      roles = canvas_api_permissions[params[:type]] + canvas_api_permissions[:common]
+      roles = canvas_api_permissions[:default] if roles.empty?
+      roles
+    end
+
+    def canvas_api_permissions
+      @canvas_api_permissions ||= current_application_instance.application.canvas_api_permissions
     end
 
     class CanvasApiTokenRequired < LMS::Canvas::CanvasException

--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -100,10 +100,8 @@ module Concerns
       # store lti roles for the user
       roles = (params["ext_roles"] || params["roles"]).split(",")
       roles.each do |role|
-        # This is hackish but we want to ensure the roles are prefixed with
-        # urn:lti: to distinguis them from internal roles
-        role = "urn:lti:role:ims/lis/#{role}" unless role.start_with?("urn:")
-        user.add_to_role(role)
+        # Only store roles that start with urn:lti:role to prevent using local roles
+        user.add_to_role(role) if role.start_with?("urn:lti:role")
       end
 
       user

--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -96,6 +96,16 @@ module Concerns
       user.lti_provider          = lti_provider
       user.lms_user_id           = params[:custom_canvas_user_id] || params[:user_id]
       user.skip_confirmation!
+
+      # store lti roles for the user
+      roles = (params["ext_roles"] || params["roles"]).split(",")
+      roles.each do |role|
+        # This is hackish but we want to ensure the roles are prefixed with
+        # urn:lti: to distinguis them from internal roles
+        role = "urn:lti:role:ims/lis/#{role}" unless role.start_with?("urn:")
+        user.add_to_role(role)
+      end
+
       user
     end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -2,6 +2,7 @@ class Application < ActiveRecord::Base
 
   serialize :default_config, HashSerializer
   serialize :lti_config, HashSerializer
+  serialize :canvas_api_permissions, HashSerializer
 
   has_many :application_instances
   validates :name, presence: true, uniqueness: true

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -26,15 +26,6 @@ Defaults: &defaults
   lti_tool_description: "A set of tools created by Atomic Jolt to handle LTI Launch and integration with the Instructure Canvas API"
   lti_launch_domain: <%= ENV["APP_ROOT_DOMAIN"] %>
 
-  hello_world_lti_key: 'lti-example'
-  hello_world_lti_secret: '<Run rake secret to get a value to put here>'
-  hello_world_subdomain: 'lti-example'
-
-  admin_lti_key: 'lti-admin'
-  admin_lti_secret: '<Run rake secret to get a value to put here>'
-  admin_subdomain: 'admin'
-
-
   # Email Settings
   application_root_domain: <%= ENV["APP_ROOT_DOMAIN"] || "ltistarterapp.com" %>
   email_provider_username: admin@example.com
@@ -62,6 +53,14 @@ Defaults: &defaults
 development:
   <<: *defaults
 
+  hello_world_lti_key: 'lti-example-dev'
+  hello_world_lti_secret: '<Run rake secret to get a value to put here>'
+  hello_world_subdomain: 'lti-example'
+
+  admin_lti_key: 'lti-admin-dev'
+  admin_lti_secret: '<Run rake secret to get a value to put here>'
+  admin_subdomain: 'admin'
+
   secret_key_base: '<Run rake secret to get a value to put here>'
 
 test:
@@ -73,6 +72,14 @@ test:
 # instead read values from the environment.
 production:
   <<: *defaults
+
+  hello_world_lti_key: 'lti-example'
+  hello_world_lti_secret: '<Run rake secret to get a value to put here>'
+  hello_world_subdomain: 'lti-example'
+
+  admin_lti_key: 'lti-admin'
+  admin_lti_secret: '<Run rake secret to get a value to put here>'
+  admin_subdomain: 'admin'
 
   application_main_domain: <%= "#{ENV['APP_SUBDOMAIN']}.herokuapp.com" %>
 

--- a/db/migrate/20170523025529_change_permissions_to_json.rb
+++ b/db/migrate/20170523025529_change_permissions_to_json.rb
@@ -1,0 +1,6 @@
+class ChangePermissionsToJson < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :applications, :canvas_api_permissions
+    add_column :applications, :canvas_api_permissions, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170503011153) do
+ActiveRecord::Schema.define(version: 20170523025529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,11 +47,11 @@ ActiveRecord::Schema.define(version: 20170503011153) do
     t.string   "client_application_name"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
-    t.text     "canvas_api_permissions"
     t.integer  "kind",                        default: 0
     t.integer  "application_instances_count"
     t.jsonb    "default_config",              default: {}
     t.jsonb    "lti_config"
+    t.jsonb    "canvas_api_permissions",      default: {}
   end
 
   create_table "authentications", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,17 +13,37 @@ sites = [
   },
 ]
 
-admin_api_permissions = %w(
-  LIST_ACTIVE_COURSES_IN_ACCOUNT
-  LIST_EXTERNAL_TOOLS_COURSES
-  CREATE_EXTERNAL_TOOL_COURSES
-  DELETE_EXTERNAL_TOOL_COURSES
-  LIST_EXTERNAL_TOOLS_ACCOUNTS
-  CREATE_EXTERNAL_TOOL_ACCOUNTS
-  DELETE_EXTERNAL_TOOL_ACCOUNTS
-  GET_SUB_ACCOUNTS_OF_ACCOUNT
-  HELPER_ALL_ACCOUNTS
-).join(",")
+# Each API endpoint must include a list of LTI and internal roles that are allowed to call the endpoint.
+# A list of possible roles is available in the IMS LTI specification:
+# https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-41
+# If an endpoint does not list a role then the roles listed under "default" will be used.
+# Roles included in "common" will be merged into each API endpoint's roles.
+#
+# Examples roles from Canvas LTI launch
+# urn:lti:instrole:ims/lis/Administrator, Institution Role
+# urn:lti:instrole:ims/lis/Instructor,    Institution Role
+# urn:lti:instrole:ims/lis/Student,       Institution Role
+# urn:lti:role:ims/lis/Instructor,        Context Role
+# urn:lti:role:ims/lis/Learner,           Context Role
+# urn:lti:sysrole:ims/lis/User            System Role
+
+admin_api_permissions = {
+  default: [
+    "administrator", # Internal (non-LTI) role
+    "urn:lti:sysrole:ims/lis/SysAdmin",
+    "urn:lti:sysrole:ims/lis/Administrator",
+  ],
+  common: [],
+  LIST_ACTIVE_COURSES_IN_ACCOUNT: [],
+  LIST_EXTERNAL_TOOLS_COURSES: [],
+  CREATE_EXTERNAL_TOOL_COURSES: [],
+  DELETE_EXTERNAL_TOOL_COURSES: [],
+  LIST_EXTERNAL_TOOLS_ACCOUNTS: [],
+  CREATE_EXTERNAL_TOOL_ACCOUNTS: [],
+  DELETE_EXTERNAL_TOOL_ACCOUNTS: [],
+  GET_SUB_ACCOUNTS_OF_ACCOUNT: [],
+  HELPER_ALL_ACCOUNTS: [],
+}
 
 # Add an LTI Application
 applications = [
@@ -47,7 +67,17 @@ applications = [
     description: "LTI Starter App by Atomic Jolt",
     client_application_name: "hello_world",
     # List Canvas API methods the app is allowed to use. A full list of constants can be found in canvas_urls
-    canvas_api_permissions: "LIST_ACCOUNTS",
+    canvas_api_permissions: {
+      default: [],
+      common: [],
+      LIST_ACCOUNTS: [
+        "urn:lti:sysrole:ims/lis/SysAdmin",
+        "urn:lti:sysrole:ims/lis/Administrator",
+        "urn:lti:instrole:ims/lis/Administrator",
+        "urn:lti:instrole:ims/lis/Instructor",
+        "urn:lti:role:ims/lis/Instructor",
+      ],
+    },
     default_config: {},
     lti_config: {
       title: "LTI Starter App",

--- a/spec/controllers/api/canvas_proxy_controller_spec.rb
+++ b/spec/controllers/api/canvas_proxy_controller_spec.rb
@@ -2,13 +2,28 @@ require "rails_helper"
 
 RSpec.describe Api::CanvasProxyController, type: :controller do
   before do
+    canvas_api_permissions = {
+      default: [
+        "administrator", # Internal (non-LTI) role
+        "urn:lti:sysrole:ims/lis/SysAdmin",
+        "urn:lti:sysrole:ims/lis/Administrator",
+        "urn:lti:role:ims/lis/Learner",
+      ],
+      common: [],
+      LIST_ACCOUNTS: [],
+      LIST_YOUR_COURSES: [],
+      CREATE_NEW_SUB_ACCOUNT: [],
+      UPDATE_ACCOUNT: [],
+    }
     @application = FactoryGirl.create(
       :application,
-      canvas_api_permissions: "LIST_ACCOUNTS,LIST_YOUR_COURSES,CREATE_NEW_SUB_ACCOUNT,UPDATE_ACCOUNT",
+      canvas_api_permissions: canvas_api_permissions,
     )
     @application_instance = FactoryGirl.create(:application_instance, application: @application)
     @user = FactoryGirl.create(:user)
     @user.confirm
+    @user.add_to_role("urn:lti:role:ims/lis/Learner")
+    @user.save!
     @user_token = AuthToken.issue_token({ user_id: @user.id })
   end
 

--- a/spec/controllers/api/lti_content_item_selection_controller_spec.rb
+++ b/spec/controllers/api/lti_content_item_selection_controller_spec.rb
@@ -4,7 +4,18 @@ RSpec.describe Api::LtiContentItemSelectionController, type: :controller do
   before do
     @application = FactoryGirl.create(
       :application,
-      canvas_api_permissions: "LIST_ACCOUNTS,LIST_YOUR_COURSES,CREATE_NEW_SUB_ACCOUNT,UPDATE_ACCOUNT",
+      canvas_api_permissions: {
+        default: [
+          "administrator", # Internal (non-LTI) role
+          "urn:lti:sysrole:ims/lis/SysAdmin",
+          "urn:lti:sysrole:ims/lis/Administrator",
+        ],
+        common: [],
+        LIST_ACCOUNTS: [],
+        LIST_YOUR_COURSES: [],
+        CREATE_NEW_SUB_ACCOUNT: [],
+        UPDATE_ACCOUNT: [],
+      },
     )
     @application_instance = FactoryGirl.create(:application_instance, application: @application)
     allow(controller).to receive(:current_application_instance).and_return(@application_instance)

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,6 +1,17 @@
 FactoryGirl.define do
   factory :application do
     name { FactoryGirl.generate(:name) }
-    canvas_api_permissions "LIST_ACCOUNTS,LIST_ACCOUNT_ADMINS"
+    canvas_api_permissions do
+      {
+        default: [
+          "administrator", # Internal (non-LTI) role
+          "urn:lti:sysrole:ims/lis/SysAdmin",
+          "urn:lti:sysrole:ims/lis/Administrator",
+        ],
+        common: [],
+        LIST_ACCOUNTS: [],
+        LIST_ACCOUNT_ADMINS: [],
+      }
+    end
   end
 end


### PR DESCRIPTION
This commit contains breaking changes. Previously Canvas API Permissions were specified as a comma delimited string i.e. "LIST_ACCOUNTS, LIST_YOUR_COURSES, CREATE_NEW_SUB_ACCOUNT, UPDATE_ACCOUNT"

These changes require that each API call be associated with a role. A default may also be supplied which will be used in the event that the API endpoint is associated with an empty array. Values placed in common will be merged into all API endpoints i.e.

canvas_api_permissions = {
      default: [
        "administrator", # Internal (non-LTI) role
        "urn:lti:sysrole:ims/lis/SysAdmin",
        "urn:lti:sysrole:ims/lis/Administrator",
        "urn:lti:role:ims/lis/Learner",
      ],
      common: [],
      LIST_ACCOUNTS: [],
      LIST_YOUR_COURSES: [],
      CREATE_NEW_SUB_ACCOUNT: [],
      UPDATE_ACCOUNT: [],
    }