### PR TITLE
Refactor protect_canvas_api to accept keyword arguments

### DIFF
--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -33,17 +33,19 @@ module Concerns
       )
     end
 
-    def protect_canvas_api
-      if canvas_api_permissions.has_key?(params[:type]) &&
-          allowed_roles.present? &&
-          (allowed_roles & current_user.nil_or_context_roles(params[:context_id]).map(&:name)).present?
-        return
-      end
+    def protect_canvas_api(type: params[:type], context_id: params[:context_id])
+      return if canvas_api_authorized(type: type, context_id: context_id)
       user_not_authorized
     end
 
-    def allowed_roles
-      roles = (canvas_api_permissions[params[:type]] || []) + (canvas_api_permissions[:common] || [])
+    def canvas_api_authorized(type: params[:type], context_id: params[:context_id])
+      canvas_api_permissions.has_key?(type) &&
+        allowed_roles(type: type).present? &&
+        (allowed_roles(type: type) & current_user.nil_or_context_roles(context_id).map(&:name)).present?
+    end
+
+    def allowed_roles(type: params[:type])
+      roles = (canvas_api_permissions[type] || []) + (canvas_api_permissions[:common] || [])
       roles = canvas_api_permissions[:default] || [] if roles.empty?
       roles
     end

--- a/client/libs/middleware/api.js
+++ b/client/libs/middleware/api.js
@@ -4,6 +4,8 @@ import { DONE } from '../constants/wrapper';
 export function apiRequest(store, action) {
   const state = store.getState();
   const updatedParams = {
+    // Add the context id from the lti launch
+    context_id: state.settings.context_id,
     // Add consumer key to requests to indicate which lti app requests are originating from.
     oauth_consumer_key: state.settings.oauth_consumer_key,
     ...action.params


### PR DESCRIPTION
This makes it possible to authorize actions that don't have a type passed in.