### PR TITLE
Channel all OAuth requests through a single domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 1.0.0
+Channels all OAuth requests through a single domain. The applications root domain will be used in combination with
+the value defined by "oauth_subdomain" in secrets.yml. i.e. <oauth_subdomain>.<application_root_domain>

--- a/app/controllers/api/lti_launches_controller.rb
+++ b/app/controllers/api/lti_launches_controller.rb
@@ -7,12 +7,10 @@ class Api::LtiLaunchesController < Api::ApiApplicationController
   before_action :set_configs, only: [:create]
 
   def create
+    @lti_launch.save!
     result = {
       lti_launch: @lti_launch,
     }
-
-    @lti_launch.save!
-
     if content_item = params[:content_item].to_json
 
       # HACK. We are replacing path directly in the json

--- a/app/lib/middleware/oauth_state_middleware.rb
+++ b/app/lib/middleware/oauth_state_middleware.rb
@@ -3,20 +3,79 @@ class OauthStateMiddleware
     @app = app
   end
 
+  def query_string(request, nonce)
+    query = "?code=#{request.params['code']}"
+    query << "&state=#{request.params['state']}"
+    query << "&nonce=#{nonce}"
+    query
+  end
+
+  def signed_query_string(query_string, secret)
+    "#{query_string}&signature=#{sign(query_string, secret)}"
+  end
+
+  # Generates a signature given data and a secret
+  def sign(str, secret)
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret, str)
+  end
+
+  # Verifies the signature value in a request
+  def verify!(request, secret)
+    query = query_string(request, request.params["nonce"])
+    unless request.params["signature"] == sign(query, secret)
+      raise OauthStateMiddlewareException, "OAuth state signatures do not match"
+    end
+  end
+
+  # Since we channel all OAuth request through a single domain we have to have a way
+  # to send the user back to their original subdomain.
+  def redirect_original(request, state_params, application_instance)
+    response = Rack::Response.new
+    return_url = state_params["app_callback_url"]
+    query = query_string(request, DateTime.now.to_i)
+    return_url << signed_query_string(query, application_instance.site.oauth_secret)
+    puts "*************************************************************************************"
+    puts "redirecting to #{return_url}"
+    puts "*************************************************************************************"
+    response.redirect return_url
+    response.finish
+  end
+
+  # Adds all parameters back into the request
+  def restore_state(request, state_params, application_instance, oauth_state, env)
+    verify!(request, application_instance.site.oauth_secret)
+    # Restore the param from before the OAuth dance
+    state_params.each do |key, value|
+      request.update_param(key, value)
+    end
+    puts "*************************************************************************************"
+    puts "restored params #{oauth_state.payload}"
+    puts "*************************************************************************************"
+    oauth_state.destroy
+    env["canvas.url"] = application_instance.site.url
+  end
+
+  # Retrieves all original app parameters (settings) from the database during
+  # an OAuth callback
+  def get_state(request)
+    if request.params["state"].present? && request.params["code"].present?
+      if oauth_state = OauthState.find_by(state: request.params["state"])
+        [oauth_state, JSON.parse(oauth_state.payload) || {}]
+      else
+        raise OauthStateMiddlewareException, "Invalid state during OAuth callback"
+      end
+    end
+  end
+
   def call(env)
     request = Rack::Request.new(env)
-    if request.params["state"] && request.params["code"]
-      if oauth_state = OauthState.find_by(state: request.params["state"])
-        # Restore the param from before the OAuth dance
-        state_params = JSON.parse(oauth_state.payload) || {}
-        state_params.each do |key, value|
-          request.update_param(key, value)
-        end
-        application_instance = ApplicationInstance.find_by(lti_key: state_params["oauth_consumer_key"])
-        env["canvas.url"] = application_instance.site.url
-        oauth_state.destroy
+    oauth_state, state_params = get_state(request)
+    if oauth_state.present?
+      application_instance = ApplicationInstance.find_by(lti_key: state_params["oauth_consumer_key"])
+      if request.params["signature"].present?
+        restore_state(request, state_params, application_instance, oauth_state, env)
       else
-        raise OauthStateMiddlewareException, "Invalid state in OAuth callback"
+        return redirect_original(request, state_params, application_instance)
       end
     end
     @app.call(env)

--- a/app/lib/middleware/oauth_state_middleware.rb
+++ b/app/lib/middleware/oauth_state_middleware.rb
@@ -34,6 +34,7 @@ class OauthStateMiddleware
     response = Rack::Response.new
     return_url = state_params["app_callback_url"]
     query = query_string(request, SecureRandom.hex(64))
+    return_url << "?"
     return_url << signed_query_string(query, application_instance.site.oauth_secret)
     response.redirect return_url
     response.finish

--- a/app/lib/middleware/oauth_state_middleware.rb
+++ b/app/lib/middleware/oauth_state_middleware.rb
@@ -35,14 +35,14 @@ class OauthStateMiddleware
     return_url = state_params["app_callback_url"]
     query = query_string(request, SecureRandom.hex(64))
     return_url << "?"
-    return_url << signed_query_string(query, application_instance.site.oauth_secret)
+    return_url << signed_query_string(query, application_instance.lti_secret)
     response.redirect return_url
     response.finish
   end
 
   # Adds all parameters back into the request
   def restore_state(request, state_params, application_instance, oauth_state, env)
-    verify!(request, application_instance.site.oauth_secret)
+    verify!(request, application_instance.lti_secret)
     # Restore the param from before the OAuth dance
     state_params.each do |key, value|
       request.update_param(key, value)

--- a/app/lib/middleware/oauth_state_middleware.rb
+++ b/app/lib/middleware/oauth_state_middleware.rb
@@ -34,9 +34,6 @@ class OauthStateMiddleware
     return_url = state_params["app_callback_url"]
     query = query_string(request, DateTime.now.to_i)
     return_url << signed_query_string(query, application_instance.site.oauth_secret)
-    puts "*************************************************************************************"
-    puts "redirecting to #{return_url}"
-    puts "*************************************************************************************"
     response.redirect return_url
     response.finish
   end
@@ -48,9 +45,6 @@ class OauthStateMiddleware
     state_params.each do |key, value|
       request.update_param(key, value)
     end
-    puts "*************************************************************************************"
-    puts "restored params #{oauth_state.payload}"
-    puts "*************************************************************************************"
     oauth_state.destroy
     env["canvas.url"] = application_instance.site.url
   end

--- a/app/views/shared/_default_admin_client_settings.html.erb
+++ b/app/views/shared/_default_admin_client_settings.html.erb
@@ -9,8 +9,8 @@
     settings[:display_name]        = current_user.display_name
     settings[:lti_key]             = current_application_instance.lti_key
     settings[:user_canvas_domains] = current_user.authentications.pluck(:provider_url)
-    settings[:canvas_oauth_url]    = user_canvas_omniauth_authorize_url
-    settings[:canvas_callback_url] = user_canvas_omniauth_callback_url
+    settings[:canvas_oauth_url]    = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
+    settings[:canvas_callback_url] = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
     settings[:sign_out_url]        = destroy_user_session_url
   end
 %>

--- a/app/views/shared/_default_admin_client_settings.html.erb
+++ b/app/views/shared/_default_admin_client_settings.html.erb
@@ -9,9 +9,13 @@
     settings[:display_name]        = current_user.display_name
     settings[:lti_key]             = current_application_instance.lti_key
     settings[:user_canvas_domains] = current_user.authentications.pluck(:provider_url)
-    settings[:canvas_oauth_url]    = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
-    settings[:canvas_callback_url] = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
     settings[:sign_out_url]        = destroy_user_session_url
+
+    # OAuth related params
+    settings[:app_callback_url]     = user_canvas_omniauth_callback_url
+    settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
+    settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
+    settings[:canvas_auth_required] = @canvas_auth_required
   end
 %>
 <script type="text/javascript">

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -4,28 +4,30 @@
     csrf_token: form_authenticity_token
   }
   if signed_in?
-    settings[:user_id] = current_user.id
-    settings[:email] = current_user.email
+    settings[:user_id]      = current_user.id
+    settings[:email]        = current_user.email
     settings[:display_name] = current_user.display_name
+
+    # LMS related params
+    settings[:canvas_url]  = @canvas_url
+    settings[:lti_user_id] = current_user.lti_user_id
+    settings[:lms_user_id] = current_user.lms_user_id
+
+    # OAuth related params
+    settings[:app_callback_url]     = user_canvas_omniauth_callback_url
+    settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
+    settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
+    settings[:canvas_auth_required] = @canvas_auth_required
 
     if @lti_launch
       settings[:lti_launch_config] = @lti_launch.config
     end
 
     if @is_lti_launch
-      settings[:canvas_url]                             = @canvas_url
       settings[:oauth_consumer_key]                     = params[:oauth_consumer_key]
       settings[:lms_course_id]                          = params[:custom_canvas_course_id]
-      settings[:lti_user_id]                            = current_user.lti_user_id
-      settings[:lms_user_id]                            = current_user.lms_user_id
       settings[:lti_provider]                           = lti_provider
       settings[:lms_course_name]                        = params[:context_title]
-
-      # OAuth related params
-      settings[:app_callback_url]                       = user_canvas_omniauth_callback_url
-      settings[:canvas_oauth_url]                       = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
-      settings[:canvas_callback_url]                    = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
-      settings[:canvas_auth_required]                   = @canvas_auth_required
 
       # LTI parameters
       settings[:context_id]                             = params["context_id"]

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -20,8 +20,11 @@
       settings[:lms_user_id]                            = current_user.lms_user_id
       settings[:lti_provider]                           = lti_provider
       settings[:lms_course_name]                        = params[:context_title]
-      settings[:canvas_oauth_url]                       = user_canvas_omniauth_authorize_url
-      settings[:canvas_callback_url]                    = user_canvas_omniauth_callback_url
+
+      # OAuth related params
+      settings[:app_callback_url]                       = user_canvas_omniauth_callback_url
+      settings[:canvas_oauth_url]                       = user_canvas_omniauth_authorize_url(subdomain: Rails.application.secrets.oauth_subdomain)
+      settings[:canvas_callback_url]                    = user_canvas_omniauth_callback_url(subdomain: Rails.application.secrets.oauth_subdomain)
       settings[:canvas_auth_required]                   = @canvas_auth_required
 
       # LTI parameters

--- a/client/apps/admin/components/application_instances/form.jsx
+++ b/client/apps/admin/components/application_instances/form.jsx
@@ -76,43 +76,6 @@ export default class Form extends React.Component {
     );
   }
 
-  renderOauthConfiguration() {
-
-    const siteId = parseInt(this.props.site_id, 10);
-    const site = _.find(this.props.sites, s => s.id === siteId);
-
-    if (_.isEmpty(site)) { return null; }
-
-    const OAuthKey = site.oauth_key;
-
-    return (
-      <div className="o-grid__item u-full">
-        <h3 className="c-modal__subtitle">OAuth Configuration</h3>
-        <p className="c-modal__info">
-          Per user OAuth can be configured by adding the callback url below to
-          the existing developer id/key with the id of {OAuthKey}.
-        </p>
-        <p className="c-modal__info">Follow these steps:</p>
-        <ol className="c-modal__info">
-          <li>
-            Copy this url: <span className="c-modal__important">{oauthCallbackUrl(this.props.domain)}</span>
-          </li>
-          <li>
-            <a href={canvasDevKeysUrl(site)} className="c-modal__subtext-link" target="_blank" rel="noopener noreferrer" >
-              Click here to visit the Canvas devloper keys page.
-            </a>
-          </li>
-          <li>
-            Find the developer id {OAuthKey}
-          </li>
-          <li>
-            Paste in the url copied above and save the form.
-          </li>
-        </ol>
-      </div>
-    );
-  }
-
   render() {
     const options = _.map(this.props.sites, site => ({
       label: site.url,
@@ -190,7 +153,6 @@ export default class Form extends React.Component {
               warning={erroneousLtiConfigWarning}
             />
           </div>
-          {this.renderOauthConfiguration()}
         </div>
         <button
           type="button"

--- a/client/apps/admin/components/sites/modal.jsx
+++ b/client/apps/admin/components/sites/modal.jsx
@@ -87,7 +87,7 @@ export class SiteModal extends React.Component {
       canvasDevInstructions = (
         <div>
           <div>
-            You will need a redirect URI: {callbackUrl}
+            Use the redirect URI: {callbackUrl}
           </div>
           <div>
             <a href={canvasDevKeysUrl(site)} className="c-modal__subtext-link" target="_blank" rel="noopener noreferrer" >

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -90,10 +90,6 @@ end
 Rails.application.config.middleware.insert_before Warden::Manager, Apartment::Elevators::Generic, lambda { |request|
   key = request.params["oauth_consumer_key"]
   host = request.host_with_port
-  puts "*************************************************************************************"
-  puts "key #{key}"
-  puts "host #{host}"
-  puts "*************************************************************************************"
   if application_instance = ApplicationInstance.find_by(lti_key: key) || ApplicationInstance.find_by(domain: host)
     application_instance.tenant
   else

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -90,6 +90,10 @@ end
 Rails.application.config.middleware.insert_before Warden::Manager, Apartment::Elevators::Generic, lambda { |request|
   key = request.params["oauth_consumer_key"]
   host = request.host_with_port
+  puts "*************************************************************************************"
+  puts "key #{key}"
+  puts "host #{host}"
+  puts "*************************************************************************************"
   if application_instance = ApplicationInstance.find_by(lti_key: key) || ApplicationInstance.find_by(domain: host)
     application_instance.tenant
   else

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,7 @@ OmniAuth.config.before_request_phase do |env|
   OauthState.create!(state: state, payload: request.params.to_json)
   env["omniauth.strategy"].options[:authorize_params].state = state
 
-  # Bye default omniauth will store all params in the session. The code above
+  # By default omniauth will store all params in the session. The code above
   # stores the values in the database so we remove the values from the session
   # since the amount of data in the original params object will overflow the
   # allowed cookie size

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -42,6 +42,9 @@ Defaults: &defaults
   canvas_developer_id: <%= ENV["CANVAS_DEVELOPER_ID"] %>
   canvas_developer_key: <%= ENV["CANVAS_DEVELOPER_KEY"] %>
 
+  # Single subdomain where all OAuth redirects will be sent
+  oauth_subdomain: "auth"
+
   auth0_client_id: lti_starter_app
   auth0_client_secret: '<Run rake secret to get a value to put here>'
 

--- a/spec/lib/middleware/oauth_state_middleware_spec.rb
+++ b/spec/lib/middleware/oauth_state_middleware_spec.rb
@@ -4,26 +4,66 @@ require "rack/mock"
 describe OauthStateMiddleware do
   before do
     @application_instance = FactoryGirl.create(:application_instance)
+    @app_callback_url = "http://atomic.example.com"
     @payload = {
       oauth_consumer_key: @application_instance.lti_key,
+      app_callback_url: @app_callback_url,
     }
     @oauth_state = FactoryGirl.create(:oauth_state, payload: @payload.to_json)
     @state = @oauth_state.state
     @code = "1234"
-
+    @nonce = SecureRandom.hex(64)
     app = lambda { |env| }
-    @env = Rack::MockRequest.env_for("http://example.com?state=#{@state}&code=#{@code}")
     @middleware = OauthStateMiddleware.new(app)
   end
 
-  it "Restores env based on existing oauth_state" do
-    @middleware.call(@env)
-    expect(@env["canvas.url"]).to eq(@application_instance.site.url)
-    request = Rack::Request.new(@env)
-    expect(request.params["oauth_consumer_key"]).to eq(@application_instance.lti_key)
+  context "Initial request after OAuth response" do
+    before do
+      @env = Rack::MockRequest.env_for("http://example.com?state=#{@state}&code=#{@code}")
+    end
+
+    it "doesn't delete the oauth state" do
+      @middleware.call(@env)
+      oauth_state = OauthState.find(@oauth_state.id)
+      expect(oauth_state).to eq(@oauth_state)
+    end
+
+    it "signs the redirect" do
+      response = @middleware.call(@env)
+      location = response[1]["Location"]
+      query = Rack::Utils.parse_nested_query(location)
+      expect(query["signature"].present?).to be true
+    end
+
+    it "redirects back to the original app url" do
+      response = @middleware.call(@env)
+      expect(response[0]).to be(302)
+      expect(response[1]["Location"].starts_with?(@app_callback_url)).to be true
+    end
   end
 
-  it "Deletes the Oauth State" do
-    expect { @middleware.call(@env) }.to change { OauthState.count }.by(-1)
+  context "Redirect to original url" do
+    before do
+      query = {
+        code: @code,
+        state: @state,
+        nonce: @nonce,
+      }.to_query
+      return_url = @app_callback_url
+      return_url << "?"
+      return_url << @middleware.signed_query_string(query, @application_instance.lti_secret)
+      @env = Rack::MockRequest.env_for(return_url)
+    end
+    it "Restores env based on existing oauth_state" do
+      @middleware.call(@env)
+      expect(@env["canvas.url"]).to eq(@application_instance.site.url)
+      request = Rack::Request.new(@env)
+      expect(request.params["oauth_consumer_key"]).to eq(@application_instance.lti_key)
+    end
+
+    it "Deletes the Oauth State" do
+      expect { @middleware.call(@env) }.to change { OauthState.count }.by(-1)
+    end
   end
+
 end


### PR DESCRIPTION
Channels all OAuth requests through a single domain. The applications root domain will be used in combination with
the value defined by "oauth_subdomain" in secrets.yml. i.e. <oauth_subdomain>.<application_root_domain>