### PR TITLE
Remove uniqueness constraint on BundleInstance.entity_key

### DIFF
--- a/app/models/bundle_instance.rb
+++ b/app/models/bundle_instance.rb
@@ -3,7 +3,6 @@ class BundleInstance < ApplicationRecord
   belongs_to :site
   has_many :application_instances
   has_many :applications, through: :bundle
-  validates :entity_key, uniqueness: true
 
   def self.entity_key_from_url(url)
     UrlHelper.host(url)

--- a/spec/models/bundle_instance_spec.rb
+++ b/spec/models/bundle_instance_spec.rb
@@ -2,11 +2,6 @@ require "rails_helper"
 
 RSpec.describe BundleInstance, type: :model do
   describe "entity_key" do
-    it "should have unique entity_key" do
-      BundleInstance.create!(entity_key: "abc")
-      expect { BundleInstance.create!(entity_key: "abc") }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
     describe "entity_key_from_url" do
       it "should return key" do
         url = "http://sub.domain.example.com"


### PR DESCRIPTION
A site can have instances of many bundles, who all share the same entity key. So the entity_key cannot be unique. 