### PR TITLE
Refactor canvas support

### DIFF
--- a/app/controllers/api/canvas_proxy_controller.rb
+++ b/app/controllers/api/canvas_proxy_controller.rb
@@ -8,7 +8,7 @@ class Api::CanvasProxyController < Api::ApiApplicationController
     api = if params[:bundle_instance_token].present?
             canvas_api(application_instance: targeted_app_instance)
           else
-            canvas_api(application_instance: current_application_instance)
+            canvas_api
           end
     result = api.proxy(params[:lms_proxy_call_type], params.to_unsafe_h, request.body.read, params[:get_all])
     allowed_headers = %w{

--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -4,43 +4,55 @@ module Concerns
 
     protected
 
-    def canvas_api(application_instance: current_application_instance)
+    def canvas_api(
+      application_instance: current_application_instance,
+      user: current_user
+    )
+      url = UrlHelper.scheme_host_port(application_instance.site.url)
       if application_instance.canvas_token.present?
-        LMS::Canvas.new(
-          UrlHelper.scheme_host_port(application_instance.site.url),
-          application_instance.canvas_token,
-        )
-      elsif auth = canvas_auth(application_instance)
-        options = {
-          client_id: application_instance.site.oauth_key,
-          client_secret: application_instance.site.oauth_secret,
-          redirect_uri: user_canvas_omniauth_callback_url(
-            subdomain: Application::AUTH,
-            protocol: "https",
-          ),
-          refresh_token: auth.refresh_token,
-        }
-        LMS::Canvas.new(
-          UrlHelper.scheme_host_port(application_instance.site.url),
-          auth,
-          options,
-        )
+        global_auth(url, application_instance.canvas_token)
+      elsif auth = canvas_auth(application_instance.site, user: user)
+        user_auth(auth, url, application_instance.site)
       else
         raise CanvasApiTokenRequired, "Could not find a global or user canvas api token."
       end
     end
 
-    def canvas_auth(application_instance)
-      return nil unless current_user.present?
-      current_user.authentications.find_by(
-        provider_url: UrlHelper.scheme_host_port(application_instance.site.url),
+    def global_auth(url, canvas_token)
+      LMS::Canvas.new(
+        url,
+        canvas_token,
+      )
+    end
+
+    def user_auth(auth, url, site)
+      options = {
+        client_id: site.oauth_key,
+        client_secret: site.oauth_secret,
+        redirect_uri: Rails.application.routes.url_helpers.user_canvas_omniauth_callback_url(
+          subdomain: Application::AUTH,
+          protocol: "https",
+        ),
+        refresh_token: auth.refresh_token,
+      }
+      LMS::Canvas.new(
+        url,
+        auth,
+        options,
+      )
+    end
+
+    def canvas_auth(site, user: current_user)
+      return nil unless user.present?
+      user.authentications.find_by(
+        provider_url: UrlHelper.scheme_host_port(site.url),
       )
     end
 
     def protect_canvas_api(type: params[:lms_proxy_call_type], context_id: params[:context_id])
       return if canvas_api_authorized(type: type, context_id: context_id)
       # this is not permanent, we will remove this when we go away from using the new application instance to install
-      return if canvas_auth(current_application_instance).present?
+      return if canvas_auth(current_application_instance.site).present?
       user_not_authorized
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,6 +63,8 @@ Rails.application.configure do
     g.fixture_replacement :factory_girl, dir: "spec/factories"
   end
 
+  routes.default_url_options = { host: Rails.application.secrets.application_root_domain }
+
   # Example action_mailer config
   # config.action_mailer.smtp_settings = {
   #   address: "smtp.gmail.com",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,6 +89,8 @@ Rails.application.configure do
   #
   config.webpack[:use_manifest] = true
 
+  routes.default_url_options = { host: Rails.application.secrets.application_root_domain }
+
   # Email server config
   # config.action_mailer.smtp_settings = {
   #   address: "smtp.gmail.com",

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,5 +43,7 @@ Rails.application.configure do
   #
   # Custom configuration
   #
+
+  routes.default_url_options = { host: "localhost" }
   config.action_mailer.default_url_options = { host: "localhost" }
 end


### PR DESCRIPTION
Refactor canvas_api so user can be passed in, defaults to current_user
Separate global and user auth into methods that can be called
BREAKING CHANGE: canvas_auth now accepts a site and user
Add a routes default url host to environments