### PR TITLE
Don't use provider to find LTI user - lti user id is sufficient

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -37,7 +37,7 @@ module Concerns
 
     def user_from_lti
       lti_user_id = params[:user_id]
-      user = User.find_by(lti_provider: lti_provider, lti_user_id: lti_user_id)
+      user = User.find_by(lti_user_id: lti_user_id)
       if user.blank?
         domain = params["custom_canvas_api_domain"] || Rails.application.secrets.application_main_domain
         user = _generate_new_lti_user(params)


### PR DESCRIPTION
We obtain the LTI user id during the Oauth process but not a related lti provider id. We need to be able to find the user during the LTI launch so we are removing the requirement that the provider match - each LTI tool is scoped to it's own tenant so we shouldn't have to worry about collisions.