### PR TITLE
Update the oauth callback urls to accept a host with multiple subdomains

### DIFF
--- a/app/controllers/concerns/canvas_support.rb
+++ b/app/controllers/concerns/canvas_support.rb
@@ -1,5 +1,6 @@
 module Concerns
   module CanvasSupport
+    include ApplicationHelper
     extend ActiveSupport::Concern
 
     protected
@@ -35,7 +36,7 @@ module Concerns
         client_id: site.oauth_key,
         client_secret: site.oauth_secret,
         redirect_uri: Rails.application.routes.url_helpers.user_canvas_omniauth_callback_url(
-          subdomain: Application::AUTH,
+          host: oauth_host,
           protocol: "https",
         ),
         refresh_token: auth.refresh_token,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,13 @@ module ApplicationHelper
     params["ext_roles"] || params["roles"]
   end
 
+  ##
+  # oauth_host
+  #
+  # Allows the use of multiple subdomains listed as the root domain
+  ##
+  def oauth_host
+    "#{Application::AUTH}.#{Rails.application.secrets.application_root_domain}"
+  end
+
 end

--- a/app/views/shared/_default_admin_client_settings.html.erb
+++ b/app/views/shared/_default_admin_client_settings.html.erb
@@ -13,8 +13,8 @@
 
     # OAuth related params
     settings[:app_callback_url]     = user_canvas_omniauth_callback_url
-    settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(subdomain: Application::AUTH)
-    settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(subdomain: Application::AUTH)
+    settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(host: oauth_host)
+    settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(host: oauth_host)
     settings[:canvas_auth_required] = @canvas_auth_required
   end
 %>

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -7,8 +7,8 @@
 
   # OAuth related params
   settings[:app_callback_url]     = user_canvas_omniauth_callback_url
-  settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(subdomain: Application::AUTH)
-  settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(subdomain: Application::AUTH)
+  settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(host: oauth_host)
+  settings[:canvas_callback_url]  = user_canvas_omniauth_callback_url(host: oauth_host)
   settings[:canvas_auth_required] = @canvas_auth_required
   settings[:canvas_url] = canvas_url
 


### PR DESCRIPTION
This resolves a problem if you have several subdomains you want to use. ie:

If you have 
```
my.great.app.com
```

Previously it would generate
```
auth.app.com
```

but now the oauth callback url can be
```
auth.my.great.app.com
```