### PR TITLE
Refresh JWT with existing jwt data

### DIFF
--- a/app/controllers/api/jwts_controller.rb
+++ b/app/controllers/api/jwts_controller.rb
@@ -1,7 +1,8 @@
 class Api::JwtsController < Api::ApiApplicationController
 
   def show
-    token = AuthToken.issue_token({ user_id: current_user.id })
+    old_token_attrs = decoded_jwt_token(request)&.except("iat", "exp", "aud")
+    token = AuthToken.issue_token(old_token_attrs)
     respond_to do |format|
       format.json { render json: { jwt: token } }
     end


### PR DESCRIPTION
When a JWT is refreshed, we currently loose all the custom data that was added to it.
This fixes it so all existing data is kept in the refreshed JWT.