### PR TITLE
Remove extra yarn test

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -8,6 +8,5 @@ do
   yarn test || SUCCESS=false
   cd ../..
 done
-yarn test || SUCCESS=false
 
 $SUCCESS


### PR DESCRIPTION
Fixes yarn test warning:
```
No tests found
In /Users/jamescarbine/Documents/projects/lti_starter_app/client
  178 files checked.
  testMatch: **/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x) - 57 matches
  testPathIgnorePatterns: /node_modules/,/apps/ - 2 matches
```