### PR TITLE
Fix skip confirm

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -101,13 +101,13 @@ module Concerns
       end
 
       user = User.new(email: email, name: name)
+      user.skip_confirmation!
       user.password = ::SecureRandom::hex(15)
       user.password_confirmation = user.password
       user.lti_user_id = lti_user_id
       user.lti_provider = lti_provider
       user.lms_user_id = params[:custom_canvas_user_id] || params[:user_id]
       user.create_method = User.create_methods[:oauth]
-      user.skip_confirmation!
 
       # store lti roles for the user
       _add_roles(user, params)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -141,9 +141,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def find_using_oauth
     return if @user # Previous filter was successful and we already have a user
     if @user = User.for_auth(request.env["omniauth.auth"])
+      @user.skip_confirmation!
       kind = params[:action].titleize
       @user.update_oauth(request.env["omniauth.auth"])
-      @user.skip_confirmation!
       if kind == "Canvas"
         @user.add_to_role("canvas_oauth_user")
       end
@@ -157,12 +157,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth = request.env["omniauth.auth"]
     kind = params[:action].titleize # Should give us Facebook, Twitter, Linked In, etc
     @user = User.new
+    @user.skip_confirmation!
     @user.password = SecureRandom.hex(15)
     @user.password_confirmation = @user.password
     @user.create_method = User.create_methods[:oauth]
     @user.lti_user_id = auth["extra"]["raw_info"]["lti_user_id"]
     @user.apply_oauth(auth)
-    @user.skip_confirmation!
     if kind == "Canvas"
       @user.add_to_role("canvas_oauth_user")
     end


### PR DESCRIPTION
Move skip confirm to exactly after user is created in memory.
This avoids in the downstream apps from adding code before the skip confirm that saves the user to the database.