### PR TITLE
Support single domains for application instances

### DIFF
--- a/app/controllers/api/ims_exports_controller.rb
+++ b/app/controllers/api/ims_exports_controller.rb
@@ -26,7 +26,7 @@ class Api::ImsExportsController < ApplicationController
     )
     ImsExportJob.perform_later(
       export,
-      current_application_instance,
+      @application_instance,
       ims_export_params.to_json,
     )
     response = {

--- a/app/controllers/concerns/canvas_imscc_support.rb
+++ b/app/controllers/concerns/canvas_imscc_support.rb
@@ -13,8 +13,8 @@ module Concerns
     def validate_token
       decoded_token = AuthToken.decode(encoded_token, nil, false)
       lti_key = decoded_token[1]["kid"]
-      if application_instance = ApplicationInstance.find_by(lti_key: lti_key)
-        token = AuthToken.valid?(encoded_token, application_instance.lti_secret)
+      if @application_instance = ApplicationInstance.find_by(lti_key: lti_key)
+        token = AuthToken.valid?(encoded_token, @application_instance.lti_secret)
         raise InvalidTokenError, "Unable to decode IMSCC jwt token" if token.blank?
         raise InvalidTokenError, "Invalid IMSCC jwt token payload" if token.empty?
         token[0]

--- a/app/helpers/jwt_helper.rb
+++ b/app/helpers/jwt_helper.rb
@@ -10,6 +10,7 @@ module JwtHelper
       attrs[:lti_roles] = current_user_roles(context_id: params[:context_id])
       attrs[:context_id] = params[:context_id]
       attrs[:lms_course_id] = params[:custom_canvas_course_id]
+      attrs[:kid] = params[:oauth_consumer_key]
     end
     AuthToken.issue_token(attrs)
   end

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -73,7 +73,7 @@ class ApplicationInstance < ActiveRecord::Base
   end
 
   def set_domain
-    self.domain = domain || "#{key}.#{Rails.application.secrets.application_root_domain}"
+    self.domain = domain || "#{application.key}.#{Rails.application.secrets.application_root_domain}"
   end
 
   def create_schema

--- a/spec/controllers/concerns/canvas_imscc_support_spec.rb
+++ b/spec/controllers/concerns/canvas_imscc_support_spec.rb
@@ -73,4 +73,10 @@ describe ApplicationController, type: :controller do
     json = JSON.parse(response.body)
     expect(json["message"]).to eq("all is well")
   end
+
+  it "sets @application_instance" do
+    request.headers["Authorization"] = "Bearer #{@token}"
+    post :create, params: {}, format: :json
+    expect(assigns(:application_instance)).to eq(@application_instance)
+  end
 end

--- a/spec/models/application_instance_spec.rb
+++ b/spec/models/application_instance_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ApplicationInstance, type: :model do
       @application_instance = create(:application_instance, lti_key: lti_key, site: @site, application: @application)
       expect(@application_instance.key).to eq(lti_key)
       expect(@application_instance.lti_key).to eq(lti_key)
-      expect(@application_instance.domain).to eq("#{lti_key}.#{Rails.application.secrets.application_root_domain}")
+      domain = "#{@application.key}.#{Rails.application.secrets.application_root_domain}"
+      expect(@application_instance.domain).to eq(domain)
     end
 
     it "sets a default lti key" do
@@ -36,7 +37,7 @@ RSpec.describe ApplicationInstance, type: :model do
         site: @site,
         application: @application,
       )
-      application_instance_domain = "#{@application_instance.key}.#{Rails.application.secrets.application_root_domain}"
+      application_instance_domain = "#{@application.key}.#{Rails.application.secrets.application_root_domain}"
       expect(@application_instance.domain).to eq(application_instance_domain)
     end
 


### PR DESCRIPTION
* Don’t use a dasherized domain of `site.key-application.key` and use just the `application.key`
* Update Apartment to function with just the consumer key and not the domain the request comes in on.
  * This allows backwards compatibility with dasherized subdomains
  * Pull the consumer key out of the jwt via the `kid` attribute.