### PR TITLE
Order application instances by the oldest

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -9,6 +9,7 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
 
   def index
     @application_instances = @application_instances.
+      by_oldest.
       paginate(page: params[:page], per_page: 30)
     application_instances = @application_instances.map do |app_inst|
       authentications = get_authentications(app_inst)

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -33,6 +33,9 @@ class ApplicationInstance < ActiveRecord::Base
   before_create :create_config
 
   scope :for_tenant, ->(tenant) { where(tenant: tenant) }
+  scope :by_newest, -> { order(created_at: :desc) }
+  scope :by_oldest, -> { order(created_at: :asc) }
+  scope :by_latest, -> { order(updated_at: :desc) }
 
   def lti_config_xml
     domain = self.domain || Rails.application.secrets.application_main_domain

--- a/spec/controllers/api/application_instances_controller_spec.rb
+++ b/spec/controllers/api/application_instances_controller_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Api::ApplicationInstancesController, type: :controller do
         get :index, params: { application_id: @application.id }, format: :json
         expect(response).to have_http_status(200)
       end
+
+      it "renders all application instances by oldest" do
+        app = create(:application)
+        ai1 = create(:application_instance, application: app, created_at: 1.week.ago)
+        ai2 = create(:application_instance, application: app, created_at: 2.week.ago)
+        ai3 = create(:application_instance, application: app, created_at: 1.day.ago)
+        ai4 = create(:application_instance, application: app, created_at: 3.days.ago)
+        get :index, params: { application_id: app.id }, format: :json
+        result = JSON.parse(response.body)
+        expected_instance_ids = [ai2.id, ai1.id, ai4.id, ai3.id]
+        returned_instance_ids = result["application_instances"].map { |ai| ai["id"] }
+        expect(returned_instance_ids).to eq(expected_instance_ids)
+      end
     end
 
     describe "GET show" do


### PR DESCRIPTION
This fixes the admin tool displaying app instances in seemingly random order.