### PR TITLE
Add sortable columns to admin tool

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -9,7 +9,7 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
 
   def index
     @application_instances = @application_instances.
-      by_oldest.
+      order(sort_column.to_sym => sort_direction.to_sym).
       paginate(page: params[:page], per_page: 30)
     set_requests
     application_instances = @application_instances.map do |app_inst|
@@ -68,6 +68,21 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
   end
 
   private
+
+  def sortable_columns
+    [
+      "created_at",
+      "lti_key",
+    ]
+  end
+
+  def sort_column
+    sortable_columns.include?(params[:column]) ? params[:column] : "created_at"
+  end
+
+  def sort_direction
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : "desc"
+  end
 
   def get_authentications(application_instance_instance)
     Apartment::Tenant.switch(application_instance_instance.tenant) do

--- a/client/apps/admin/actions/application_instances.js
+++ b/client/apps/admin/actions/application_instances.js
@@ -18,13 +18,15 @@ const requests = [
 
 export const Constants = wrapper(actions, requests);
 
-export function getApplicationInstances(applicationId, page) {
+export function getApplicationInstances(applicationId, page, column, direction) {
   return {
     type: Constants.GET_APPLICATION_INSTANCES,
     method: Network.GET,
     url: `/api/applications/${applicationId}/application_instances`,
     params: {
       page,
+      column,
+      direction,
     }
   };
 }

--- a/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
+++ b/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
@@ -255,8 +255,8 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "column": "lti_key",
-                "currentSortColumn": undefined,
-                "currentSortDirection": undefined,
+                "currentColumn": undefined,
+                "currentDirection": undefined,
                 "setSort": undefined,
                 "title": "LTI KEY",
               },
@@ -362,8 +362,8 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "column": "created_at",
-                "currentSortColumn": undefined,
-                "currentSortDirection": undefined,
+                "currentColumn": undefined,
+                "currentDirection": undefined,
                 "setSort": undefined,
                 "title": "CREATED",
               },
@@ -773,8 +773,8 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "column": "lti_key",
-                  "currentSortColumn": undefined,
-                  "currentSortDirection": undefined,
+                  "currentColumn": undefined,
+                  "currentDirection": undefined,
                   "setSort": undefined,
                   "title": "LTI KEY",
                 },
@@ -880,8 +880,8 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "column": "created_at",
-                  "currentSortColumn": undefined,
-                  "currentSortDirection": undefined,
+                  "currentColumn": undefined,
+                  "currentDirection": undefined,
                   "setSort": undefined,
                   "title": "CREATED",
                 },

--- a/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
+++ b/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
@@ -255,8 +255,8 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "column": "lti_key",
-                "currentColumn": undefined,
-                "currentDirection": undefined,
+                "currentSortColumn": undefined,
+                "currentSortDirection": undefined,
                 "setSort": undefined,
                 "title": "LTI KEY",
               },
@@ -362,8 +362,8 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "column": "created_at",
-                "currentColumn": undefined,
-                "currentDirection": undefined,
+                "currentSortColumn": undefined,
+                "currentSortDirection": undefined,
                 "setSort": undefined,
                 "title": "CREATED",
               },
@@ -773,8 +773,8 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "column": "lti_key",
-                  "currentColumn": undefined,
-                  "currentDirection": undefined,
+                  "currentSortColumn": undefined,
+                  "currentSortDirection": undefined,
                   "setSort": undefined,
                   "title": "LTI KEY",
                 },
@@ -880,8 +880,8 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "column": "created_at",
-                  "currentColumn": undefined,
-                  "currentDirection": undefined,
+                  "currentSortColumn": undefined,
+                  "currentSortDirection": undefined,
                   "setSort": undefined,
                   "title": "CREATED",
                 },

--- a/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
+++ b/client/apps/admin/components/application_instances/__snapshots__/list.spec.jsx.snap
@@ -43,11 +43,10 @@ ShallowWrapper {
       "children": Array [
         <thead>
           <tr>
-            <th>
-              <span>
-                LTI KEY
-              </span>
-            </th>
+            <Sortable
+              column="lti_key"
+              title="LTI KEY"
+            />
             <th>
               <span>
                 SETTINGS
@@ -68,11 +67,10 @@ ShallowWrapper {
                 AUTHS
               </span>
             </th>
-            <th>
-              <span>
-                CREATED
-              </span>
-            </th>
+            <Sortable
+              column="created_at"
+              title="CREATED"
+            />
             <th>
               ________
             </th>
@@ -134,11 +132,10 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": <tr>
-            <th>
-              <span>
-                LTI KEY
-              </span>
-            </th>
+            <Sortable
+              column="lti_key"
+              title="LTI KEY"
+            />
             <th>
               <span>
                 SETTINGS
@@ -159,11 +156,10 @@ ShallowWrapper {
                 AUTHS
               </span>
             </th>
-            <th>
-              <span>
-                CREATED
-              </span>
-            </th>
+            <Sortable
+              column="created_at"
+              title="CREATED"
+            />
             <th>
               ________
             </th>
@@ -197,11 +193,10 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": Array [
-              <th>
-                <span>
-                  LTI KEY
-                </span>
-              </th>,
+              <Sortable
+                column="lti_key"
+                title="LTI KEY"
+              />,
               <th>
                 <span>
                   SETTINGS
@@ -222,11 +217,10 @@ ShallowWrapper {
                   AUTHS
                 </span>
               </th>,
-              <th>
-                <span>
-                  CREATED
-                </span>
-              </th>,
+              <Sortable
+                column="created_at"
+                title="CREATED"
+              />,
               <th>
                 ________
               </th>,
@@ -258,25 +252,17 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "host",
+              "nodeType": "function",
               "props": Object {
-                "children": <span>
-                  LTI KEY
-                </span>,
+                "column": "lti_key",
+                "currentColumn": undefined,
+                "currentDirection": undefined,
+                "setSort": undefined,
+                "title": "LTI KEY",
               },
               "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "LTI KEY",
-                },
-                "ref": null,
-                "rendered": "LTI KEY",
-                "type": "span",
-              },
-              "type": "th",
+              "rendered": null,
+              "type": [Function],
             },
             Object {
               "instance": null,
@@ -373,25 +359,17 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "host",
+              "nodeType": "function",
               "props": Object {
-                "children": <span>
-                  CREATED
-                </span>,
+                "column": "created_at",
+                "currentColumn": undefined,
+                "currentDirection": undefined,
+                "setSort": undefined,
+                "title": "CREATED",
               },
               "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "CREATED",
-                },
-                "ref": null,
-                "rendered": "CREATED",
-                "type": "span",
-              },
-              "type": "th",
+              "rendered": null,
+              "type": [Function],
             },
             Object {
               "instance": null,
@@ -583,11 +561,10 @@ ShallowWrapper {
         "children": Array [
           <thead>
             <tr>
-              <th>
-                <span>
-                  LTI KEY
-                </span>
-              </th>
+              <Sortable
+                column="lti_key"
+                title="LTI KEY"
+              />
               <th>
                 <span>
                   SETTINGS
@@ -608,11 +585,10 @@ ShallowWrapper {
                   AUTHS
                 </span>
               </th>
-              <th>
-                <span>
-                  CREATED
-                </span>
-              </th>
+              <Sortable
+                column="created_at"
+                title="CREATED"
+              />
               <th>
                 ________
               </th>
@@ -674,11 +650,10 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <tr>
-              <th>
-                <span>
-                  LTI KEY
-                </span>
-              </th>
+              <Sortable
+                column="lti_key"
+                title="LTI KEY"
+              />
               <th>
                 <span>
                   SETTINGS
@@ -699,11 +674,10 @@ ShallowWrapper {
                   AUTHS
                 </span>
               </th>
-              <th>
-                <span>
-                  CREATED
-                </span>
-              </th>
+              <Sortable
+                column="created_at"
+                title="CREATED"
+              />
               <th>
                 ________
               </th>
@@ -737,11 +711,10 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <th>
-                  <span>
-                    LTI KEY
-                  </span>
-                </th>,
+                <Sortable
+                  column="lti_key"
+                  title="LTI KEY"
+                />,
                 <th>
                   <span>
                     SETTINGS
@@ -762,11 +735,10 @@ ShallowWrapper {
                     AUTHS
                   </span>
                 </th>,
-                <th>
-                  <span>
-                    CREATED
-                  </span>
-                </th>,
+                <Sortable
+                  column="created_at"
+                  title="CREATED"
+                />,
                 <th>
                   ________
                 </th>,
@@ -798,25 +770,17 @@ ShallowWrapper {
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "function",
                 "props": Object {
-                  "children": <span>
-                    LTI KEY
-                  </span>,
+                  "column": "lti_key",
+                  "currentColumn": undefined,
+                  "currentDirection": undefined,
+                  "setSort": undefined,
+                  "title": "LTI KEY",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "LTI KEY",
-                  },
-                  "ref": null,
-                  "rendered": "LTI KEY",
-                  "type": "span",
-                },
-                "type": "th",
+                "rendered": null,
+                "type": [Function],
               },
               Object {
                 "instance": null,
@@ -913,25 +877,17 @@ ShallowWrapper {
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "function",
                 "props": Object {
-                  "children": <span>
-                    CREATED
-                  </span>,
+                  "column": "created_at",
+                  "currentColumn": undefined,
+                  "currentDirection": undefined,
+                  "setSort": undefined,
+                  "title": "CREATED",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "CREATED",
-                  },
-                  "ref": null,
-                  "rendered": "CREATED",
-                  "type": "span",
-                },
-                "type": "th",
+                "rendered": null,
+                "type": [Function],
               },
               Object {
                 "instance": null,

--- a/client/apps/admin/components/application_instances/index.jsx
+++ b/client/apps/admin/components/application_instances/index.jsx
@@ -45,8 +45,8 @@ export class Index extends React.Component {
     this.state = {
       modalOpen: false,
       currentPage: null,
-      column: 'created_at',
-      direction: 'desc',
+      sortColumn: 'created_at',
+      sortDirection: 'desc',
     };
   }
 
@@ -69,37 +69,37 @@ export class Index extends React.Component {
   componentWillMount() {
     const {
       currentPage,
-      column,
-      direction,
+      sortColumn,
+      sortDirection,
     } = this.state;
 
     this.props.getApplicationInstances(
       this.props.params.applicationId,
       currentPage,
-      column,
-      direction,
+      sortColumn,
+      sortDirection,
     );
   }
 
   componentDidUpdate(prevProps, prevState) {
     const {
       currentPage,
-      column,
-      direction,
+      sortColumn,
+      sortDirection,
     } = this.state;
 
     const propsChanged = (
       prevState.currentPage !== currentPage ||
-      prevState.column !== column ||
-      prevState.direction !== direction
+      prevState.sortColumn !== sortColumn ||
+      prevState.sortDirection !== sortDirection
     );
 
     if (propsChanged) {
       this.props.getApplicationInstances(
         this.props.params.applicationId,
         currentPage,
-        column,
-        direction,
+        sortColumn,
+        sortDirection,
       );
     }
   }
@@ -108,10 +108,10 @@ export class Index extends React.Component {
     this.setState({ currentPage: change.selected + 1 });
   }
 
-  setSort(column, direction) {
+  setSort(sortColumn, sortDirection) {
     this.setState({
-      column,
-      direction,
+      sortColumn,
+      sortDirection,
     });
   }
 
@@ -119,8 +119,8 @@ export class Index extends React.Component {
     const { application } = this;
 
     const {
-      column:currentColumn,
-      direction:currentDirection,
+      sortColumn:currentSortColumn,
+      sortDirection:currentSortDirection,
     } = this.state;
 
     return (
@@ -142,9 +142,9 @@ export class Index extends React.Component {
             deleteApplicationInstance={this.props.deleteApplicationInstance}
             disableApplicationInstance={this.props.disableApplicationInstance}
             canvasOauthURL={this.props.canvasOauthURL}
-            setSort={(column, direction) => this.setSort(column, direction)}
-            currentColumn={currentColumn}
-            currentDirection={currentDirection}
+            setSort={(sortColumn, sortDirection) => this.setSort(sortColumn, sortDirection)}
+            currentSortColumn={currentSortColumn}
+            currentSortDirection={currentSortDirection}
           />
           <Pagination
             setPage={change => this.setPage(change)}

--- a/client/apps/admin/components/application_instances/index.jsx
+++ b/client/apps/admin/components/application_instances/index.jsx
@@ -45,6 +45,8 @@ export class Index extends React.Component {
     this.state = {
       modalOpen: false,
       currentPage: null,
+      column: 'created_at',
+      direction: 'desc',
     };
   }
 
@@ -67,18 +69,38 @@ export class Index extends React.Component {
   componentWillMount() {
     const {
       currentPage,
+      column,
+      direction,
     } = this.state;
 
-    this.props.getApplicationInstances(this.props.params.applicationId, currentPage);
+    this.props.getApplicationInstances(
+      this.props.params.applicationId,
+      currentPage,
+      column,
+      direction,
+    );
   }
 
   componentDidUpdate(prevProps, prevState) {
     const {
       currentPage,
+      column,
+      direction,
     } = this.state;
 
-    if (prevState.currentPage !== currentPage) {
-      this.props.getApplicationInstances(this.props.params.applicationId, currentPage);
+    const propsChanged = (
+      prevState.currentPage !== currentPage ||
+      prevState.column !== column ||
+      prevState.direction !== direction
+    );
+
+    if (propsChanged) {
+      this.props.getApplicationInstances(
+        this.props.params.applicationId,
+        currentPage,
+        column,
+        direction,
+      );
     }
   }
 
@@ -86,8 +108,20 @@ export class Index extends React.Component {
     this.setState({ currentPage: change.selected + 1 });
   }
 
+  setSort(column, direction) {
+    this.setState({
+      column,
+      direction,
+    });
+  }
+
   render() {
     const { application } = this;
+
+    const {
+      column:currentColumn,
+      direction:currentDirection,
+    } = this.state;
 
     return (
       <div>
@@ -108,6 +142,9 @@ export class Index extends React.Component {
             deleteApplicationInstance={this.props.deleteApplicationInstance}
             disableApplicationInstance={this.props.disableApplicationInstance}
             canvasOauthURL={this.props.canvasOauthURL}
+            setSort={(column, direction) => this.setSort(column, direction)}
+            currentColumn={currentColumn}
+            currentDirection={currentDirection}
           />
           <Pagination
             setPage={change => this.setPage(change)}

--- a/client/apps/admin/components/application_instances/list.jsx
+++ b/client/apps/admin/components/application_instances/list.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import ListRow from './list_row';
+import Sortable from '../common/sortable';
 
 export default function List(props) {
   const {
@@ -11,19 +12,34 @@ export default function List(props) {
     saveApplicationInstance,
     deleteApplicationInstance,
     canvasOauthURL,
-    disableApplicationInstance
+    disableApplicationInstance,
+    setSort,
+    currentColumn,
+    currentDirection,
   } = props;
 
   return (
     <table className="c-table c-table--instances">
       <thead>
         <tr>
-          <th><span>LTI KEY</span></th>
+          <Sortable
+            title="LTI KEY"
+            column="lti_key"
+            currentColumn={currentColumn}
+            currentDirection={currentDirection}
+            setSort={setSort}
+          />
           <th><span>SETTINGS</span></th>
           <th><span>CONFIG XML</span></th>
           <th><span>ENABLED</span></th>
           <th><span>AUTHS</span></th>
-          <th><span>CREATED</span></th>
+          <Sortable
+            title="CREATED"
+            column="created_at"
+            currentColumn={currentColumn}
+            currentDirection={currentDirection}
+            setSort={setSort}
+          />
           <th>________</th>
           <th><span>REQUESTS</span></th>
           <th><span>LTI LAUNCHES</span></th>

--- a/client/apps/admin/components/application_instances/list.jsx
+++ b/client/apps/admin/components/application_instances/list.jsx
@@ -25,8 +25,8 @@ export default function List(props) {
           <Sortable
             title="LTI KEY"
             column="lti_key"
-            currentSortColumn={currentSortColumn}
-            currentSortDirection={currentSortDirection}
+            currentColumn={currentSortColumn}
+            currentDirection={currentSortDirection}
             setSort={setSort}
           />
           <th><span>SETTINGS</span></th>
@@ -36,8 +36,8 @@ export default function List(props) {
           <Sortable
             title="CREATED"
             column="created_at"
-            currentSortColumn={currentSortColumn}
-            currentSortDirection={currentSortDirection}
+            currentColumn={currentSortColumn}
+            currentDirection={currentSortDirection}
             setSort={setSort}
           />
           <th>________</th>

--- a/client/apps/admin/components/application_instances/list.jsx
+++ b/client/apps/admin/components/application_instances/list.jsx
@@ -14,8 +14,8 @@ export default function List(props) {
     canvasOauthURL,
     disableApplicationInstance,
     setSort,
-    currentColumn,
-    currentDirection,
+    currentSortColumn,
+    currentSortDirection,
   } = props;
 
   return (
@@ -25,8 +25,8 @@ export default function List(props) {
           <Sortable
             title="LTI KEY"
             column="lti_key"
-            currentColumn={currentColumn}
-            currentDirection={currentDirection}
+            currentSortColumn={currentSortColumn}
+            currentSortDirection={currentSortDirection}
             setSort={setSort}
           />
           <th><span>SETTINGS</span></th>
@@ -36,8 +36,8 @@ export default function List(props) {
           <Sortable
             title="CREATED"
             column="created_at"
-            currentColumn={currentColumn}
-            currentDirection={currentDirection}
+            currentSortColumn={currentSortColumn}
+            currentSortDirection={currentSortDirection}
             setSort={setSort}
           />
           <th>________</th>

--- a/client/apps/admin/components/common/sortable.jsx
+++ b/client/apps/admin/components/common/sortable.jsx
@@ -5,14 +5,14 @@ export default function Sortable(props) {
   const {
     title,
     column,
-    currentSortColumn,
-    currentSortDirection,
+    currentColumn,
+    currentDirection,
     setSort,
   } = props;
 
-  const direction = column === currentSortColumn && currentSortDirection === 'asc' ? 'desc' : 'asc';
-  let icon = currentSortDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
-  icon = column === currentSortColumn ? icon : '';
+  const direction = column === currentColumn && currentDirection === 'asc' ? 'desc' : 'asc';
+  let icon = currentDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
+  icon = column === currentColumn ? icon : '';
 
   return (
     <th className="sortable-header" onClick={() => setSort(column, direction)}>
@@ -29,7 +29,7 @@ export default function Sortable(props) {
 Sortable.propTypes = {
   title: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
-  currentSortColumn: PropTypes.string.isRequired,
-  currentSortDirection: PropTypes.string.isRequired,
+  currentColumn: PropTypes.string.isRequired,
+  currentDirection: PropTypes.string.isRequired,
   setSort: PropTypes.func.isRequired,
 };

--- a/client/apps/admin/components/common/sortable.jsx
+++ b/client/apps/admin/components/common/sortable.jsx
@@ -10,18 +10,12 @@ export default function Sortable(props) {
     setSort,
   } = props;
 
-  const styles = {
-    clicker: {
-      cursor: 'pointer',
-    },
-  };
-
   const direction = column === currentColumn && currentDirection === 'asc' ? 'desc' : 'asc';
   let icon = currentDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
   icon = column === currentColumn ? icon : '';
 
   return (
-    <th style={styles.clicker} onClick={() => setSort(column, direction)}>
+    <th className="sortable-header" onClick={() => setSort(column, direction)}>
       <span>
         {title}
         <i className="material-icons">

--- a/client/apps/admin/components/common/sortable.jsx
+++ b/client/apps/admin/components/common/sortable.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Sortable(props) {
+  const {
+    title,
+    column,
+    currentColumn,
+    currentDirection,
+    setSort,
+  } = props;
+
+  const direction = column === currentColumn && currentDirection === 'asc' ? 'desc' : 'asc';
+  let icon = currentDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
+  icon = column === currentColumn ? icon : '';
+
+  return (
+    <th onClick={() => setSort(column, direction)}>
+      <span>
+        {title}
+        <i className="material-icons">
+          {icon}
+        </i>
+      </span>
+    </th>
+  );
+}
+
+Sortable.propTypes = {
+  title: PropTypes.string.isRequired,
+  column: PropTypes.string.isRequired,
+  currentColumn: PropTypes.string.isRequired,
+  currentDirection: PropTypes.string.isRequired,
+  setSort: PropTypes.func.isRequired,
+};

--- a/client/apps/admin/components/common/sortable.jsx
+++ b/client/apps/admin/components/common/sortable.jsx
@@ -10,12 +10,18 @@ export default function Sortable(props) {
     setSort,
   } = props;
 
+  const styles = {
+    clicker: {
+      cursor: 'pointer',
+    },
+  };
+
   const direction = column === currentColumn && currentDirection === 'asc' ? 'desc' : 'asc';
   let icon = currentDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
   icon = column === currentColumn ? icon : '';
 
   return (
-    <th onClick={() => setSort(column, direction)}>
+    <th style={styles.clicker} onClick={() => setSort(column, direction)}>
       <span>
         {title}
         <i className="material-icons">

--- a/client/apps/admin/components/common/sortable.jsx
+++ b/client/apps/admin/components/common/sortable.jsx
@@ -5,14 +5,14 @@ export default function Sortable(props) {
   const {
     title,
     column,
-    currentColumn,
-    currentDirection,
+    currentSortColumn,
+    currentSortDirection,
     setSort,
   } = props;
 
-  const direction = column === currentColumn && currentDirection === 'asc' ? 'desc' : 'asc';
-  let icon = currentDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
-  icon = column === currentColumn ? icon : '';
+  const direction = column === currentSortColumn && currentSortDirection === 'asc' ? 'desc' : 'asc';
+  let icon = currentSortDirection === 'asc' ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
+  icon = column === currentSortColumn ? icon : '';
 
   return (
     <th className="sortable-header" onClick={() => setSort(column, direction)}>
@@ -29,7 +29,7 @@ export default function Sortable(props) {
 Sortable.propTypes = {
   title: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
-  currentColumn: PropTypes.string.isRequired,
-  currentDirection: PropTypes.string.isRequired,
+  currentSortColumn: PropTypes.string.isRequired,
+  currentSortDirection: PropTypes.string.isRequired,
   setSort: PropTypes.func.isRequired,
 };

--- a/client/apps/admin/components/lti_installs/index.jsx
+++ b/client/apps/admin/components/lti_installs/index.jsx
@@ -16,8 +16,12 @@ import InstallPane from './install_pane';
 function select(state, props) {
   const instanceId = props.params.applicationInstanceId;
 
+  const applicationInstance = _.find(state.applicationInstances.applicationInstances, ai => (
+    `${ai.id}` === instanceId
+  ));
+
   return {
-    applicationInstance: state.applicationInstances.applicationInstances[instanceId],
+    applicationInstance,
     applications: state.applications,
     accounts: state.accounts.accounts,
     rootAccount: _.find(state.accounts.accounts, { parent_account_id: null }),

--- a/client/apps/admin/reducers/application_instances.js
+++ b/client/apps/admin/reducers/application_instances.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { Constants as ApplicationInstancesConstants } from '../actions/application_instances';
 
 const initialState = {
-  applicationInstances: {},
+  applicationInstances: [],
   totalPages: 1,
 };
 
@@ -19,7 +19,7 @@ export default function instances(state = initialState, action) {
         const instanceClone = _.cloneDeep(instance);
         instanceClone.config = JSON.stringify(instance.config);
         instanceClone.lti_config = JSON.stringify(instance.lti_config);
-        newState.applicationInstances[instance.id] = instanceClone;
+        newState.applicationInstances.push(instanceClone);
       });
       newState.totalPages = totalPages;
       return newState;
@@ -33,13 +33,18 @@ export default function instances(state = initialState, action) {
       const instanceClone = _.cloneDeep(action.payload);
       instanceClone.config = JSON.stringify(action.payload.config);
       instanceClone.lti_config = JSON.stringify(action.payload.lti_config);
-      newState.applicationInstances[action.payload.id] = instanceClone;
+      _.remove(newState.applicationInstances, ai => (
+        `${ai.id}` === action.payload.id
+      ));
+      newState.applicationInstances.push(instanceClone);
       return newState;
     }
 
     case ApplicationInstancesConstants.DELETE_APPLICATION_INSTANCE_DONE: {
       const newState = _.cloneDeep(state);
-      delete newState.applicationInstances[action.original.applicationInstanceId];
+      _.remove(newState.applicationInstances, ai => (
+        `${ai.id}` === action.original.applicationInstanceId
+      ));
       return newState;
     }
 

--- a/client/apps/admin/reducers/application_instances.spec.js
+++ b/client/apps/admin/reducers/application_instances.spec.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import * as ApplicationInstancesActions from '../actions/application_instances';
 import applicationInstances from './application_instances';
 
@@ -5,12 +6,12 @@ describe('application_instances reducer', () => {
   describe('initial state', () => {
     it('returns empty state', () => {
       const initialState = {
-        applicationInstances: {},
+        applicationInstances: [],
         totalPages: 1,
       };
-      const state = applicationInstances(initialState, {});
+      const state = applicationInstances(initialState, []);
       expect(state).toEqual({
-        applicationInstances: {},
+        applicationInstances: [],
         totalPages: 1,
       });
     });
@@ -31,8 +32,11 @@ describe('application_instances reducer', () => {
         type: 'GET_APPLICATION_INSTANCES_DONE',
         payload: { application_instances: [{ config, id: payloadId }], total_pages: 1 }
       });
-      expect(results.applicationInstances[payloadId].config).toBe(`${config}`);
-      expect(results.applicationInstances[payloadId].id).toBe(payloadId);
+      const applicationInstance = _.find(results.applicationInstances, ai => (
+        `${ai.id}` === `${payloadId}`
+      ));
+      expect(applicationInstance.config).toBe(`${config}`);
+      expect(applicationInstance.id).toBe(payloadId);
     });
   });
 
@@ -53,8 +57,11 @@ describe('application_instances reducer', () => {
         type: 'GET_APPLICATION_INSTANCE_DONE',
         payload: { config, id: payloadId }
       });
-      expect(results.applicationInstances[payloadId].config).toBe(`${config}`);
-      expect(results.applicationInstances[payloadId].id).toBe(payloadId);
+      const applicationInstance = _.find(results.applicationInstances, ai => (
+        `${ai.id}` === `${payloadId}`
+      ));
+      expect(applicationInstance.config).toBe(`${config}`);
+      expect(applicationInstance.id).toBe(payloadId);
     });
   });
 
@@ -73,7 +80,10 @@ describe('application_instances reducer', () => {
         type: 'DELETE_APPLICATION_INSTANCE_DONE',
         original: { applicationInstanceId }
       });
-      expect(results[applicationInstanceId]).not.toBeDefined();
+      const applicationInstance = _.find(results.applicationInstances, ai => (
+        `${ai.id}` === `${applicationInstanceId}`
+      ));
+      expect(applicationInstance).not.toBeDefined();
     });
   });
 });

--- a/client/apps/admin/styles/partials/_tables.scss
+++ b/client/apps/admin/styles/partials/_tables.scss
@@ -193,6 +193,13 @@
   }
 }
 
+.sortable-header {
+  &:hover {
+    background-color: $lighter-gray;
+    cursor: pointer;
+  }
+}
+
   .pagination{
     position: relative;
     @include center(horizontal);

--- a/spec/controllers/api/application_instances_controller_spec.rb
+++ b/spec/controllers/api/application_instances_controller_spec.rb
@@ -64,9 +64,32 @@ RSpec.describe Api::ApplicationInstancesController, type: :controller do
         ai2 = create(:application_instance, application: app, created_at: 2.week.ago)
         ai3 = create(:application_instance, application: app, created_at: 1.day.ago)
         ai4 = create(:application_instance, application: app, created_at: 3.days.ago)
-        get :index, params: { application_id: app.id }, format: :json
+        params = {
+          application_id: app.id,
+          column: :created_at,
+          direction: :asc,
+        }
+        get :index, params: params, format: :json
         result = JSON.parse(response.body)
         expected_instance_ids = [ai2.id, ai1.id, ai4.id, ai3.id]
+        returned_instance_ids = result["application_instances"].map { |ai| ai["id"] }
+        expect(returned_instance_ids).to eq(expected_instance_ids)
+      end
+
+      it "renders all application instances by lti_key" do
+        app = create(:application)
+        ai1 = create(:application_instance, application: app, lti_key: "c")
+        ai2 = create(:application_instance, application: app, lti_key: "g")
+        ai3 = create(:application_instance, application: app, lti_key: "a")
+        ai4 = create(:application_instance, application: app, lti_key: "z")
+        params = {
+          application_id: app.id,
+          column: :lti_key,
+          direction: :asc,
+        }
+        get :index, params: params, format: :json
+        result = JSON.parse(response.body)
+        expected_instance_ids = [ai3.id, ai1.id, ai2.id, ai4.id]
         returned_instance_ids = result["application_instances"].map { |ai| ai["id"] }
         expect(returned_instance_ids).to eq(expected_instance_ids)
       end


### PR DESCRIPTION
Make it sortable on lti_key and on created_at
Use an array to store data to preserve order

![sortable columns](https://user-images.githubusercontent.com/1216167/55644370-f6dc8680-5792-11e9-80f6-51ee918d10ca.gif)
