### PR TITLE
Fix lti launch requests

### DIFF
--- a/app/middleware/requests_logger.rb
+++ b/app/middleware/requests_logger.rb
@@ -16,7 +16,7 @@ class RequestsLogger
               else
                 0
               end
-    lti_launch = request.path == "/lti_launches" ? 1 : 0
+    lti_launch = request.path.match?(/^\/lti_launches/) ? 1 : 0
     error = @status.to_s.match?(/^5/) ? 1 : 0
 
     request_binds = [


### PR DESCRIPTION
Match any request path that starts with /lti_launches

ie: `"/lti_launches/ga4NE8qBEzzDo1ycz3ycJ23y"`