### PR TITLE
Improve the base ApplicationJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,19 @@
 class ApplicationJob < ActiveJob::Base
+  queue_as :default
+
+  before_perform :set_rollbar_scope
+
+  Que.error_notifier = proc do |_error, job|
+    if job[:error_count] > 17
+      QueJob.find_by(job_id: job[:job_id])&.destroy
+    end
+  end
+
+  private
+
+  def set_rollbar_scope
+    Rollbar.scope!(
+      tenant: Apartment::Tenant.current,
+    )
+  end
 end


### PR DESCRIPTION
Backport - Add a default queue
Backport - Set the rollbar scope
Set the max retry for que to 17 (effectively 3.8 days of attempting), then delete the job.