### PR TITLE
Speed up specs

### DIFF
--- a/spec/controllers/api/application_instances_controller_spec.rb
+++ b/spec/controllers/api/application_instances_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::ApplicationInstancesController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
   end
 
   context "no jwt" do

--- a/spec/controllers/api/applications_controller_spec.rb
+++ b/spec/controllers/api/applications_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::ApplicationsController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
   end
 
   context "no jwt" do

--- a/spec/controllers/api/canvas_proxy_controller_spec.rb
+++ b/spec/controllers/api/canvas_proxy_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::CanvasProxyController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
   end
 
   describe "proxy without authorization" do
@@ -18,7 +18,6 @@ RSpec.describe Api::CanvasProxyController, type: :controller do
   context "as student" do
     describe "proxy" do
       before do
-        allow(controller).to receive(:current_application_instance).and_return(@application_instance)
         allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
         request.headers["Authorization"] = @student_token
         allow(controller.request).to receive(:host).and_return("example.com")
@@ -103,7 +102,6 @@ RSpec.describe Api::CanvasProxyController, type: :controller do
       end
       context "application instance allows user token" do
         before do
-          allow(controller).to receive(:current_application_instance).and_return(@application_instance)
           allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
         end
         it "deletes the authentication and returns a status unauthorized" do
@@ -117,16 +115,10 @@ RSpec.describe Api::CanvasProxyController, type: :controller do
       end
       context "application instance doesn't allow user token" do
         before do
-          @application = FactoryBot.create(
-            :application,
+          @application_instance.application.update(
             canvas_api_permissions: @canvas_api_permissions,
             oauth_precedence: "global,application_instance,course",
           )
-          @application_instance = FactoryBot.create(
-            :application_instance,
-            application: @application,
-          )
-          allow(controller).to receive(:current_application_instance).and_return(@application_instance)
           allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
         end
         it "deletes the authentication and returns a status forbidden" do
@@ -142,7 +134,6 @@ RSpec.describe Api::CanvasProxyController, type: :controller do
 
     describe "proxy" do
       before do
-        allow(controller).to receive(:current_application_instance).and_return(@application_instance)
         allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
         request.headers["Authorization"] = @admin_token
         allow(controller.request).to receive(:host).and_return("example.com")

--- a/spec/controllers/api/ims_exports_controller_spec.rb
+++ b/spec/controllers/api/ims_exports_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::ImsExportsController, type: :controller do
   end
 
   before do
-    setup_application_and_instance
+    setup_application_instance
     @export_params = {
       tool_consumer_instance_guid: "thisisatoolconsumerguid",
       context_id: "thisisacontextid",

--- a/spec/controllers/api/ims_imports_controller_spec.rb
+++ b/spec/controllers/api/ims_imports_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::ImsImportsController, type: :controller do
   end
 
   before do
-    setup_application_and_instance
+    setup_application_instance
     tool_consumer_instance_guid = "4MRcxnx6vQbFXxhLb8005m5WXFM2Z2i8lQwhJ1QT:canvas-lms"
     initial_context_id = "a07291ea2fa1315059ed3bf0135a336d1eebe057"
     @import_context_id = "3155b3a04eba69bc0e52b987d3ffc465156daded"

--- a/spec/controllers/api/lti_content_item_selection_controller_spec.rb
+++ b/spec/controllers/api/lti_content_item_selection_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::LtiContentItemSelectionController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
 
     @content_item_return_url = "http://www.example.com/return_to_me"
     @content_item_url = "http://www.example.com/lti_launch"

--- a/spec/controllers/api/lti_launches_controller_spec.rb
+++ b/spec/controllers/api/lti_launches_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::LtiLaunchesController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
 
     @content_item = {
       "@context" => "http://purl.imsglobal.org/ctx/lti/v1/ContentItem",

--- a/spec/controllers/api/sites_controller_spec.rb
+++ b/spec/controllers/api/sites_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::SitesController, type: :controller do
   before do
     setup_lti_users
-    setup_application_and_instance
+    setup_application_instance
   end
 
   context "no jwt" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
+  before do
+    setup_application_instance
+  end
   describe "helper methods" do
     describe "#current_application_instance" do
       it "returns the current application instance" do
-        application_instance = FactoryBot.create(:application_instance)
-        request.params[:oauth_consumer_key] = application_instance.lti_key
-        expect(subject.send(:current_application_instance)).to eq(application_instance)
+        request.params[:oauth_consumer_key] = @application_instance.lti_key
+        expect(subject.send(:current_application_instance)).to eq(@application_instance)
       end
     end
 
@@ -51,16 +53,14 @@ RSpec.describe ApplicationController, type: :controller do
 
     describe "#canvas_url" do
       it "returns the canvas url" do
-        application_instance = FactoryBot.create(:application_instance)
-        request.params[:oauth_consumer_key] = application_instance.lti_key
-        expect(subject.send(:canvas_url)).to eq(application_instance.site.url)
+        request.params[:oauth_consumer_key] = @application_instance.lti_key
+        expect(subject.send(:canvas_url)).to eq(@application_instance.site.url)
       end
     end
 
     describe "Exception handlers" do
       before do
-        application_instance = FactoryBot.create(:application_instance)
-        allow(controller).to receive(:current_application_instance).and_return(application_instance)
+        allow(controller).to receive(:current_application_instance).and_return(@application_instance)
       end
 
       describe "CanCan::AccessDenied exception" do

--- a/spec/controllers/concerns/canvas_imscc_support_spec.rb
+++ b/spec/controllers/concerns/canvas_imscc_support_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe ApplicationController, type: :controller do
   before do
-    setup_application_and_instance
+    setup_application_instance
     # For authentication a JWT will be included in the Authorization header using the Bearer scheme,
     # it is signed using the shared secret for the tool and will include the stored consumer key in the
     # kid field of the token's header object.

--- a/spec/controllers/concerns/content_item_support_spec.rb
+++ b/spec/controllers/concerns/content_item_support_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 describe ApplicationController, type: :controller do
   before do
-    @app = FactoryBot.create(:application_instance)
-    allow(controller).to receive(:current_application_instance).and_return(@app)
-    allow(Application).to receive(:find_by).with(:lti_key).and_return(@app)
+    setup_application_instance
+    allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
 
     @content_item_return_url = "http://www.example.com/return_to_me"
 

--- a/spec/controllers/concerns/iframe_support_spec.rb
+++ b/spec/controllers/concerns/iframe_support_spec.rb
@@ -7,11 +7,10 @@ describe ApplicationController, type: :controller do
   render_views
 
   before do
-    @app = FactoryBot.create(:application_instance)
+    setup_application_instance
     # url when posting to anonymous controller created below.
     @launch_url = "http://test.host/anonymous"
-    allow(controller).to receive(:current_application_instance).and_return(@app)
-    allow(Application).to receive(:find_by).with(:lti_key).and_return(@app)
+    allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
   end
 
   describe "a user using Safari" do
@@ -52,13 +51,13 @@ describe ApplicationController, type: :controller do
     end
     it "should ask the user to obtain an API token" do
       params = lti_params(
-        @app.lti_key, @app.lti_secret,
+        @application_instance.lti_key, @application_instance.lti_secret,
         { "launch_url" => @launch_url, "roles" => "Instructor" }
       )
       post :index, params: params
       expect(response).to have_http_status(302)
       expect(response).to redirect_to(
-        user_canvas_omniauth_authorize_path(canvas_url: @app.site.url),
+        user_canvas_omniauth_authorize_path(canvas_url: @application_instance.site.url),
       )
     end
   end

--- a/spec/controllers/concerns/lti_support_spec.rb
+++ b/spec/controllers/concerns/lti_support_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe ApplicationController, type: :controller do
   before do
-    @application_instance = FactoryBot.create(:application_instance)
+    setup_application_instance
     @launch_url = "http://test.host/anonymous" # url when posting to anonymous controller created below.
     allow(controller).to receive(:current_application_instance).and_return(@application_instance)
     allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)

--- a/spec/controllers/lti_launches_controller_spec.rb
+++ b/spec/controllers/lti_launches_controller_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe LtiLaunchesController, type: :controller do
   render_views
 
   before do
-    @app = FactoryBot.create(:application_instance)
-    allow(controller).to receive(:current_application_instance).and_return(@app)
+    setup_application_instance
   end
 
   describe "index" do
@@ -15,8 +14,8 @@ RSpec.describe LtiLaunchesController, type: :controller do
 
     it "sets up the user and logs them in" do
       params = lti_params(
-        @app.lti_key,
-        @app.lti_secret,
+        @application_instance.lti_key,
+        @application_instance.lti_secret,
         { "launch_url" => lti_launches_url, "roles" => "Learner" },
       )
       post :index, params: params
@@ -32,8 +31,8 @@ RSpec.describe LtiLaunchesController, type: :controller do
       context_id = SecureRandom.hex(15)
       @lti_launch = FactoryBot.create(:lti_launch, context_id: context_id)
       params = lti_params(
-        @app.lti_key,
-        @app.lti_secret,
+        @application_instance.lti_key,
+        @application_instance.lti_secret,
         {
           "launch_url" => lti_launch_url(@lti_launch.token),
           "roles" => "Learner",

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
   end
 
   before do
+    setup_application_instance
     request.env["devise.mapping"] = Devise.mappings[:user] # If using Devise
     request.env["omniauth.strategy"] = MockStrategy.new
-    @app = FactoryBot.create(:application_instance)
-    allow(controller).to receive(:current_application_instance).and_return(@app)
   end
 
   describe "GET canvas" do

--- a/spec/jobs/ims_export_job_spec.rb
+++ b/spec/jobs/ims_export_job_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe ImsExportJob, type: :job do
   include ActiveJob::TestHelper
 
+  before do
+    setup_application_instance
+  end
+
   after do
     clear_enqueued_jobs
   end
@@ -10,8 +14,6 @@ RSpec.describe ImsExportJob, type: :job do
   subject { ImsExportJob }
 
   let(:export) { create(:ims_export, payload: { lti_launches: [] }) }
-
-  let(:application_instance) { create(:application_instance) }
 
   let(:ims_export_params) do
     {
@@ -25,7 +27,7 @@ RSpec.describe ImsExportJob, type: :job do
 
   it "Collects the lti launches" do
     expect(export.payload["lti_launches"]).to_not include(lti_launch)
-    subject.perform_now(export, application_instance, ims_export_params.to_json)
+    subject.perform_now(export, @application_instance, ims_export_params.to_json)
     expect(export.payload["lti_launches"].count).to eq(1)
     ll = export.payload["lti_launches"].first
     expect(ll["token"]).to include(lti_launch.token)
@@ -33,7 +35,7 @@ RSpec.describe ImsExportJob, type: :job do
 
   it "Updates the status" do
     expect do
-      subject.perform_now(export, application_instance, ims_export_params.to_json)
+      subject.perform_now(export, @application_instance, ims_export_params.to_json)
     end.to change(export, :status).to(ImsExport::COMPLETED)
   end
 end

--- a/spec/lib/integrations/canvas_api_support_spec.rb
+++ b/spec/lib/integrations/canvas_api_support_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe Integrations::CanvasApiSupport do
   before do
+    setup_application_instance
     @user = FactoryBot.create(:user)
     @canvas_course = FactoryBot.create(:canvas_course)
-    @application_instance = FactoryBot.create(:application_instance, canvas_token: nil)
+    @application_instance.update(canvas_token: nil)
     @authentication = FactoryBot.create(
       :authentication,
       provider_url: UrlHelper.scheme_host_port(@application_instance.site.url),
@@ -30,8 +31,8 @@ describe Integrations::CanvasApiSupport do
     expect(@api_support.api).to be_present
   end
   it "should find an api using a global token" do
-    application_instance = FactoryBot.create(:application_instance, canvas_token: "afakecanvastoken")
-    @api_support = Integrations::CanvasApiSupport.new(@user, @canvas_course, application_instance)
+    @application_instance.update(canvas_token: "afakecanvastoken")
+    @api_support = Integrations::CanvasApiSupport.new(@user, @canvas_course, @application_instance)
     expect(@api_support.api).to be_present
   end
 end

--- a/spec/lib/middleware/oauth_state_middleware_spec.rb
+++ b/spec/lib/middleware/oauth_state_middleware_spec.rb
@@ -71,7 +71,7 @@ describe OauthStateMiddleware do
 
   context "using oauth_consumer_key from application instance" do
     before do
-      @application_instance = FactoryBot.create(:application_instance)
+      setup_application_instance
       @app_callback_url = "http://atomic.example.com"
       @payload = {
         oauth_consumer_key: @application_instance.lti_key,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.extend ControllerMacros, type: :controller
+  config.include ApplicationInstanceHelper
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -51,6 +52,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
+    clean_tenants
     begin
       DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.clean_with(:transaction)
@@ -61,6 +63,8 @@ RSpec.configure do |config|
     ensure
       DatabaseCleaner.clean
     end
+
+    ApplicationInstanceHelper.make_application_instance
   end
 
   config.append_after(:each) do

--- a/spec/support/application_instance_helper.rb
+++ b/spec/support/application_instance_helper.rb
@@ -1,0 +1,39 @@
+module ApplicationInstanceHelper
+  def self.make_application_instance
+    canvas_api_permissions = {
+      default: [],
+      common: [],
+      LIST_ACCOUNTS: [
+        "urn:lti:sysrole:ims/lis/SysAdmin",
+        "urn:lti:sysrole:ims/lis/Administrator",
+        "urn:lti:instrole:ims/lis/Administrator",
+        "urn:lti:role:ims/lis/Instructor",
+      ],
+      LIST_YOUR_COURSES: [
+        "urn:lti:sysrole:ims/lis/SysAdmin",
+        "urn:lti:sysrole:ims/lis/Administrator",
+        "urn:lti:instrole:ims/lis/Administrator",
+        "urn:lti:role:ims/lis/Instructor",
+        "urn:lti:role:ims/lis/Learner",
+      ],
+    }
+    application = FactoryBot.create(
+      :application,
+      canvas_api_permissions: canvas_api_permissions,
+    )
+
+    default_config = {}
+
+    FactoryBot.create(
+      :application_instance,
+      application: application,
+      lti_key: "global_test",
+      tenant: "global_test",
+      config: default_config,
+    )
+  end
+
+  def get_application_instance
+    @application_instance ||= ApplicationInstance.find_by(lti_key: "global_test")
+  end
+end

--- a/spec/support/application_instance_helper.rb
+++ b/spec/support/application_instance_helper.rb
@@ -48,7 +48,7 @@ module ApplicationInstanceHelper
     )
   end
 
-  def get_application_instance
-    @application_instance ||= ApplicationInstance.find_by(lti_key: "global_test")
+  def global_application_instance
+    @global_application_instance ||= ApplicationInstance.find_by(lti_key: "global_test")
   end
 end

--- a/spec/support/application_instance_helper.rb
+++ b/spec/support/application_instance_helper.rb
@@ -2,20 +2,35 @@ module ApplicationInstanceHelper
   def self.make_application_instance
     canvas_api_permissions = {
       default: [],
-      common: [],
-      LIST_ACCOUNTS: [
-        "urn:lti:sysrole:ims/lis/SysAdmin",
-        "urn:lti:sysrole:ims/lis/Administrator",
-        "urn:lti:instrole:ims/lis/Administrator",
-        "urn:lti:role:ims/lis/Instructor",
+      common: [
+        "administrator",
       ],
       LIST_YOUR_COURSES: [
+        "canvas_oauth_user",
+      ],
+      LIST_ACCOUNTS: [
+        "canvas_oauth_user",
         "urn:lti:sysrole:ims/lis/SysAdmin",
         "urn:lti:sysrole:ims/lis/Administrator",
         "urn:lti:instrole:ims/lis/Administrator",
         "urn:lti:role:ims/lis/Instructor",
-        "urn:lti:role:ims/lis/Learner",
       ],
+      LIST_ENROLLMENTS_COURSES: [
+        "urn:lti:sysrole:ims/lis/SysAdmin",
+        "urn:lti:sysrole:ims/lis/Administrator",
+        "urn:lti:instrole:ims/lis/Administrator",
+        "urn:lti:role:ims/lis/Instructor",
+      ],
+      GET_SUB_ACCOUNTS_OF_ACCOUNT: [
+        "canvas_oauth_user",
+      ],
+      CREATE_NEW_SUB_ACCOUNT: [],
+      UPDATE_ACCOUNT: [],
+      # CREATE_ASSIGNMENT: [],
+      # CREATE_ASSIGNMENT_OVERRIDE: [],
+      # EDIT_ASSIGNMENT: [],
+      # DELETE_ASSIGNMENT: [],
+      # LIST_ASSIGNMENTS: [],
     }
     application = FactoryBot.create(
       :application,

--- a/spec/support/cleaner.rb
+++ b/spec/support/cleaner.rb
@@ -1,0 +1,9 @@
+def clean_tenants
+  Apartment::Tenant.switch!
+  Apartment.tenant_names.each do |name|
+    Apartment::Tenant.drop(name)
+  end
+  ApplicationInstance.destroy_all
+  Application.destroy_all
+  Site.destroy_all
+end

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -89,11 +89,11 @@ def setup_application_and_instance
 end
 
 def setup_application_instance
-  @application_instance = get_application_instance
+  @application_instance = global_application_instance
   @application = @application_instance.application
   @canvas_api_permissions = @application.canvas_api_permissions
 
   if defined?(controller)
-    allow(controller).to receive(:current_application_instance).and_return(get_application_instance)
+    allow(controller).to receive(:current_application_instance).and_return(global_application_instance)
   end
 end

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -87,3 +87,13 @@ def setup_application_and_instance
   @application_instance = FactoryBot.create(:application_instance, application: @application)
   allow(controller).to receive(:current_application_instance).and_return(@application_instance)
 end
+
+def setup_application_instance
+  @application_instance = get_application_instance
+  @application = @application_instance.application
+  @canvas_api_permissions = @application.canvas_api_permissions
+
+  if defined?(controller)
+    allow(controller).to receive(:current_application_instance).and_return(get_application_instance)
+  end
+end


### PR DESCRIPTION
This adds a helper that creates an application instance once at the beginning of the test suite instead of for every test. I mostly would like to be able to use it in our downstream projects.