### PR TITLE
Fix bad spec I introduced

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
   before do
-    setup_application_instance
+    setup_application_instance(mock_helper: false)
   end
   describe "helper methods" do
     describe "#current_application_instance" do

--- a/spec/controllers/concerns/lti_support_spec.rb
+++ b/spec/controllers/concerns/lti_support_spec.rb
@@ -4,7 +4,6 @@ describe ApplicationController, type: :controller do
   before do
     setup_application_instance
     @launch_url = "http://test.host/anonymous" # url when posting to anonymous controller created below.
-    allow(controller).to receive(:current_application_instance).and_return(@application_instance)
     allow(Application).to receive(:find_by).with(:lti_key).and_return(@application_instance)
   end
 

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -88,12 +88,12 @@ def setup_application_and_instance
   allow(controller).to receive(:current_application_instance).and_return(@application_instance)
 end
 
-def setup_application_instance
+def setup_application_instance(mock_helper: true)
   @application_instance = global_application_instance
   @application = @application_instance.application
   @canvas_api_permissions = @application.canvas_api_permissions
 
-  if defined?(controller)
+  if defined?(controller) && mock_helper
     allow(controller).to receive(:current_application_instance).and_return(global_application_instance)
   end
 end


### PR DESCRIPTION
The changes from https://github.com/atomicjolt/lti_starter_app/pull/303 made one of the application controller helper method specs just test the mocked current_application_instance, not actually test the method.