### PR TITLE
Don't use user_id from LTI launch for lms_user_id

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -61,6 +61,10 @@ module Concerns
         user = _generate_new_lti_user(params)
         _attempt_uniq_email(user)
       else
+        if user.lms_user_id.blank? && lms_user_id.present?
+          user.lms_user_id = lms_user_id
+          user.save
+        end
         _update_roles(user, params)
       end
 

--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -193,7 +193,7 @@ module Concerns
     end
 
     def lms_user_id
-      params[:custom_canvas_user_id] || params[:user_id]
+      params[:custom_canvas_user_id]
     end
 
   end


### PR DESCRIPTION
If it's not available we should leave the value null. Setting it to the user_id from params puts the LTI user id into the field which is not the same as the lms_user_id and results in inconsistent behavior. 