### PR TITLE
Move developer keys from application instances to applications

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -203,8 +203,6 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
       :anonymous,
       :rollbar_enabled,
       :domain,
-      :oauth_key,
-      :oauth_secret,
       :use_scoped_developer_key,
     )
   end

--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -18,7 +18,7 @@ class Api::ApplicationsController < Api::ApiApplicationController
   private
 
   def application_params
-    params.require(:application).permit(:name, :description)
+    params.require(:application).permit(:name, :description, :oauth_key, :oauth_secret)
   end
 
 end

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -133,6 +133,14 @@ class ApplicationInstance < ApplicationRecord
     end
   end
 
+  def oauth_key
+    site.oauth_key.presence || application.oauth_key
+  end
+
+  def oauth_secret
+    site.oauth_secret.presence || application.oauth_secret
+  end
+
   private
 
   def set_lti

--- a/client/apps/admin/components/application_instances/__snapshots__/form.spec.jsx.snap
+++ b/client/apps/admin/components/application_instances/__snapshots__/form.spec.jsx.snap
@@ -93,40 +93,6 @@ exports[`application instance form matches the snapshot 1`] = `
     >
       <Input
         className="c-input"
-        inputProps={
-          Object {
-            "id": "oauth_key_input",
-            "name": "oauth_key",
-            "onChange": [Function],
-            "type": "text",
-            "value": "",
-          }
-        }
-        labelText="Oauth Key"
-      />
-    </div>
-    <div
-      className="o-grid__item u-half"
-    >
-      <Input
-        className="c-input"
-        inputProps={
-          Object {
-            "id": "oauth_secret_input",
-            "name": "oauth_secret",
-            "onChange": [Function],
-            "type": "text",
-            "value": "",
-          }
-        }
-        labelText="Oauth Secret"
-      />
-    </div>
-    <div
-      className="o-grid__item u-half"
-    >
-      <Input
-        className="c-input"
         helperText="Current Canvas Token: undefined"
         inputProps={
           Object {

--- a/client/apps/admin/components/application_instances/form.jsx
+++ b/client/apps/admin/components/application_instances/form.jsx
@@ -144,32 +144,6 @@ export default class Form extends React.Component {
           <div className="o-grid__item u-half">
             <Input
               className="c-input"
-              labelText="Oauth Key"
-              inputProps={{
-                id: 'oauth_key_input',
-                name: 'oauth_key',
-                type: 'text',
-                value: this.props.oauth_key || '',
-                onChange,
-              }}
-            />
-          </div>
-          <div className="o-grid__item u-half">
-            <Input
-              className="c-input"
-              labelText="Oauth Secret"
-              inputProps={{
-                id: 'oauth_secret_input',
-                name: 'oauth_secret',
-                type: 'text',
-                value: this.props.oauth_secret || '',
-                onChange,
-              }}
-            />
-          </div>
-          <div className="o-grid__item u-half">
-            <Input
-              className="c-input"
               labelText="Canvas Token"
               helperText={`Current Canvas Token: ${this.props.canvas_token_preview}`}
               inputProps={{

--- a/client/apps/admin/components/applications/__snapshots__/form.spec.jsx.snap
+++ b/client/apps/admin/components/applications/__snapshots__/form.spec.jsx.snap
@@ -27,6 +27,40 @@ exports[`applications form matches the snapshot 1`] = `
     <div
       className="o-grid__item u-half"
     >
+      <Input
+        className="c-input"
+        inputProps={
+          Object {
+            "id": "oauth_key_input",
+            "name": "oauth_key",
+            "onChange": [Function],
+            "type": "text",
+            "value": "",
+          }
+        }
+        labelText="Oauth Key"
+      />
+    </div>
+    <div
+      className="o-grid__item u-half"
+    >
+      <Input
+        className="c-input"
+        inputProps={
+          Object {
+            "id": "oauth_secret_input",
+            "name": "oauth_secret",
+            "onChange": [Function],
+            "type": "text",
+            "value": "",
+          }
+        }
+        labelText="Oauth Secret"
+      />
+    </div>
+    <div
+      className="o-grid__item u-half"
+    >
       <label
         className="c-input"
         htmlFor="permissions"

--- a/client/apps/admin/components/applications/form.jsx
+++ b/client/apps/admin/components/applications/form.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Textarea from '../common/textarea';
 import Warning from '../common/warning';
+import Input from '../common/input';
 
 export default function Form(props) {
   let erroneousConfigWarning = null;
@@ -25,6 +26,32 @@ export default function Form(props) {
               onChange={props.onChange}
             />
           </label>
+        </div>
+        <div className="o-grid__item u-half">
+          <Input
+            className="c-input"
+            labelText="Oauth Key"
+            inputProps={{
+              id: 'oauth_key_input',
+              name: 'oauth_key',
+              type: 'text',
+              value: props.oauthKey || '',
+              onChange: props.onChange,
+            }}
+          />
+        </div>
+        <div className="o-grid__item u-half">
+          <Input
+            className="c-input"
+            labelText="Oauth Secret"
+            inputProps={{
+              id: 'oauth_secret_input',
+              name: 'oauth_secret',
+              type: 'text',
+              value: props.oauthSecret || '',
+              onChange: props.onChange,
+            }}
+          />
         </div>
         <div className="o-grid__item u-half">
           <label htmlFor="permissions" className="c-input">
@@ -74,4 +101,6 @@ Form.propTypes = {
   defaultConfig: PropTypes.string,
   configParseError: PropTypes.string,
   canvasApiPermissions: PropTypes.object,
+  oauthKey: PropTypes.string,
+  oauthSecret: PropTypes.string,
 };

--- a/client/apps/admin/components/applications/modal.jsx
+++ b/client/apps/admin/components/applications/modal.jsx
@@ -11,6 +11,8 @@ export default class Modal extends React.Component {
       description: PropTypes.string,
       default_config: PropTypes.string,
       canvas_api_permissions: PropTypes.object,
+      oauth_key: PropTypes.string,
+      oauth_secret: PropTypes.string,
     }),
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
@@ -60,6 +62,8 @@ export default class Modal extends React.Component {
         <h2 className="c-modal__title">{this.state.application.name} Settings</h2>
         <Form
           description={this.state.application.description}
+          oauthKey={this.state.application.oauth_key}
+          oauthSecret={this.state.application.oauth_secret}
           canvasApiPermissions={this.props.application.canvas_api_permissions}
           defaultConfig={this.state.application.default_config}
           configParseError={this.state.configParseError}

--- a/db/migrate/20200219210631_move_application_instance_developer_keys.rb
+++ b/db/migrate/20200219210631_move_application_instance_developer_keys.rb
@@ -1,0 +1,8 @@
+class MoveApplicationInstanceDeveloperKeys < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :application_instances, :oauth_key, :string
+    remove_column :application_instances, :oauth_secret, :string
+    add_column :applications, :oauth_key, :string
+    add_column :applications, :oauth_secret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_27_230659) do
+ActiveRecord::Schema.define(version: 2020_02_19_210631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,8 +41,6 @@ ActiveRecord::Schema.define(version: 2020_01_27_230659) do
     t.bigint "bundle_instance_id"
     t.boolean "anonymous", default: false
     t.boolean "rollbar_enabled", default: true
-    t.string "oauth_key"
-    t.string "oauth_secret"
     t.boolean "use_scoped_developer_key", default: true, null: false
     t.index ["application_id"], name: "index_application_instances_on_application_id"
     t.index ["lti_key"], name: "index_application_instances_on_lti_key"
@@ -66,6 +64,8 @@ ActiveRecord::Schema.define(version: 2020_01_27_230659) do
     t.jsonb "lti_advantage_config", default: {}
     t.boolean "rollbar_enabled", default: true
     t.string "oauth_scopes", default: [], array: true
+    t.string "oauth_key"
+    t.string "oauth_secret"
     t.index ["key"], name: "index_applications_on_key"
   end
 


### PR DESCRIPTION
This moves developer keys from application instances to applications. This will let us have application level global keys, and if needed we can have canvas instance level keys as well, although those will have to be shared across all applications.