### PR TITLE
Fix sending the site instead of the application instance after moving oauth keys to applications and sites.

### DIFF
--- a/app/controllers/api/application_instances_controller.rb
+++ b/app/controllers/api/application_instances_controller.rb
@@ -49,7 +49,7 @@ class Api::ApplicationInstancesController < Api::ApiApplicationController
     url = UrlHelper.scheme_host_port(site.url)
     Apartment::Tenant.switch(@application_instance.tenant) do
       auth = @application_instance.authentications.find(params[:authentication_id])
-      api = Integrations::CanvasApiSupport.refreshable_auth(auth, url, site)
+      api = Integrations::CanvasApiSupport.refreshable_auth(auth, url, @application_instance)
       if accounts = api.proxy("LIST_ACCOUNTS", {}, {}, true)
         render json: accounts
       else


### PR DESCRIPTION
Because both site and application instance have oauth_key and oauth_secret methods this would have continued to work unless the application had a different oauth key and secret than the site. Then if the token was originally created from the application oauth key it would fail to refresh.