### PR TITLE
Add LTI 1.3 Roles to Definitions

### DIFF
--- a/app/lib/lti_advantage/definitions.rb
+++ b/app/lib/lti_advantage/definitions.rb
@@ -65,6 +65,44 @@ module LtiAdvantage
     CANVAS_BETA_AUTH_TOKEN_URL = "https://canvas.beta.instructure.com/login/oauth2/token".freeze
     CANVAS_BETA_OIDC_URL = "https://canvas.beta.instructure.com/api/lti/authorize_redirect".freeze
 
+    # Roles
+    # Below are all the roles specified in the LTI 1.3 spec. (https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies-0)
+    ## Core system roles
+    ADMINISTRATOR_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator".freeze
+    NONE_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#None".freeze
+    ## Non‑core system roles
+    ACCOUNT_ADMIN_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#AccountAdmin".freeze
+    CREATOR_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#Creator".freeze
+    SYS_ADMIN_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin".freeze
+    SYS_SUPPORT_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#SysSupport".freeze
+    USER_SYSTEM_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/system/person#User".freeze
+    ## Core institution roles
+    ADMINISTRATOR_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator".freeze
+    FACULTY_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty".freeze
+    GUEST_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Guest".freeze
+    NONE_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#None".freeze
+    OTHER_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Other".freeze
+    STAFF_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff".freeze
+    STUDENT_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student".freeze
+    ## Non‑core institution roles
+    ALUMNI_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni".freeze
+    INSTRUCTOR_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor".freeze
+    LEARNER_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner".freeze
+    MEMBER_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Member".freeze
+    MENTOR_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor".freeze
+    OBSERVER_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Observer".freeze
+    PROSPECTIVE_STUDENT_INSTITUTION_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#ProspectiveStudent".freeze
+    ## Core context roles
+    ADMINISTRATOR_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator".freeze
+    CONTENT_DEVELOPER_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper".freeze
+    INSTRUCTOR_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor".freeze
+    LEARNER_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner".freeze
+    MENTOR_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor".freeze
+    ## Non‑core context roles
+    MANAGER_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Manager".freeze
+    MEMBER_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Member".freeze
+    OFFICER_CONTEXT_ROLE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Officer".freeze
+
     def self.lms_host(payload)
       host = if deep_link_launch?(payload)
                payload.dig(LtiAdvantage::Definitions::DEEP_LINKING_CLAIM, "deep_link_return_url")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,8 +22,13 @@ sites = [
 ]
 
 # Each API endpoint must include a list of LTI and internal roles that are allowed to call the endpoint.
+#
 # A list of possible roles is available in the IMS LTI specification:
 # https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-41
+# A list of LTI 1.3 roles can be found here:
+# https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies-0
+# LTI 1.3 roles are also defined in LtiAdvantage::Definitions.
+#
 # If an endpoint does not list a role then the roles listed under "default" will be used.
 # Roles included in "common" will be merged into each API endpoint's roles.
 #
@@ -104,11 +109,11 @@ applications = [
         "urn:lti:role:ims/lis/Learner",
         # LTI 1.3 roles. NOTE these have all changed and any existing applications will need to be migrated to
         # include the new roles
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
-        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
-        "http://purl.imsglobal.org/vocab/lis/v2/system/person#User",
+        LtiAdvantage::Definitions::ADMINISTRATOR_INSTITUTION_ROLE,
+        LtiAdvantage::Definitions::INSTRUCTOR_INSTITUTION_ROLE,
+        LtiAdvantage::Definitions::STUDENT_INSTITUTION_ROLE,
+        LtiAdvantage::Definitions::INSTRUCTOR_CONTEXT_ROLE,
+        LtiAdvantage::Definitions::USER_SYSTEM_ROLE,
       ],
     },
     default_config: {},


### PR DESCRIPTION
This branch adds constants for each role specified in the [LTI 1.3 spec](https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies-0).

I think it will be helpful to have a definitive list of all LTI 1.3 roles and have them set in constants so we can reference the constants instead of having multiple instances of roles as strings throughout the codebase.