### PR TITLE
Set LTI 1.3 Launch Values After Authorizing with Canvas 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -174,6 +174,18 @@ class ApplicationController < ActionController::Base
     @app_name = current_application_instance.application.client_application_name
   end
 
+  def set_lti_advantage_launch_values
+    @lti_token = LtiAdvantage::Authorization.validate_token(
+      current_application_instance,
+      params[:id_token],
+    )
+    @lti_launch_config = JSON.parse(params[:lti_launch_config]) if params[:lti_launch_config]
+    @is_deep_link = true if LtiAdvantage::Definitions.deep_link_launch?(@lti_token)
+    @app_name = current_application_instance.application.client_application_name
+    @title = current_application_instance.application.name
+    @description = current_application_instance.application.description
+  end
+
   def targeted_app_instance
     key = request.subdomains.first
     application = Application.find_by(key: key)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -28,6 +28,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to params["oauth_complete_url"]
     else
       set_lti_launch_values if params[:oauth_consumer_key].present?
+      set_lti_advantage_launch_values if params[:id_token].present?
       render "lti_launches/index", layout: "client"
     end
   end

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -25,6 +25,12 @@
 
     if @lti_launch
       settings[:lti_launch_config] = @lti_launch.config
+    elsif @lti_launch_config
+      settings[:lti_launch_config] = @lti_launch_config
+    end
+
+    if @is_deep_link
+      settings[:deep_link_settings] = @lti_token[LtiAdvantage::Definitions::DEEP_LINKING_CLAIM]
     end
 
     # Adds LTI Advantage values to settings
@@ -33,6 +39,7 @@
     if params["id_token"].present?
       # LTI 1.3 Launch
       settings[:id_token] = params["id_token"]
+      settings[:context_id] = @lti_token.dig(LtiAdvantage::Definitions::CONTEXT_CLAIM)["id"]
     elsif @is_lti_launch
       # LTI 1.0 - 1.2 Launch
       settings[:oauth_consumer_key]                     = params[:oauth_consumer_key]

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -83,12 +83,8 @@ def setup_lti_advantage_users
   )
 end
 
-def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
-  exp = 24.hours.from_now
-  nonce = SecureRandom.hex(10)
+def resource_link_claim
   {
-    "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
-    "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
     "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
       "id": "af9b5e18fe251409be18e77253d918dcf22d156e",
       "description": nil,
@@ -98,6 +94,32 @@ def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
         "errors": {},
       },
     },
+  }
+end
+
+def deep_link_settings_claim
+  {
+    "https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings": {
+      "deep_link_return_url": "https://atomicjolt.instructure.com/courses/3505/deep_linking_response?modal=true",
+      "accept_types": ["link", "file", "html", "ltiResourceLink", "image"],
+      "accept_presentation_document_targets": ["embed", "iframe", "window"],
+      "accept_media_types": "image/*,text/html,application/vnd.ims.lti.v1.ltilink,*/*",
+      "accept_multiple": true,
+      "auto_create": false,
+      "validation_context": nil,
+      "errors": {
+        "errors": {},
+      },
+    },
+  }
+end
+
+def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
+  exp = 24.hours.from_now
+  nonce = SecureRandom.hex(10)
+  payload = {
+    "https://purl.imsglobal.org/spec/lti/claim/message_type": message_type,
+    "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
     "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": {
       "scope": [
         "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
@@ -180,4 +202,9 @@ def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
       "errors": {},
     },
   }
+
+  payload.merge!(resource_link_claim) if @message_type == "LtiResourceLinkRequest"
+  payload.merge!(deep_link_settings_claim) if @message_type == "LtiDeepLinkingRequest"
+
+  payload
 end

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -1,14 +1,17 @@
 def setup_canvas_lti_advantage(
   application_instance:,
-  client_id: "43460000000000194",
+  client_id: rand(1..99999).to_s,
   iss: "https://canvas.instructure.com",
-  lti_user_id: "cfca15d8-2958-4647-a33e-a7c4b2ddab2c"
+  lti_user_id: SecureRandom.uuid,
+  context_id: SecureRandom.hex(15),
+  message_type: "LtiResourceLinkRequest"
 )
   @iss = iss
   @client_id = client_id
   @lti_user_id = lti_user_id
-  @context_id = "af9b5e18fe251409be18e77253d918dcf22d156e"
+  @context_id = context_id
   @deployment_id = "12653:#{@context_id}"
+  @message_type = message_type
 
   application_instance.site.url = "https://atomicjolt.instructure.com"
   application_instance.site.save!
@@ -29,7 +32,13 @@ def setup_canvas_lti_advantage(
   stub_canvas_jwk(application_instance.application)
 
   @id_token = JWT.encode(
-    build_payload(client_id: @client_id, iss: @iss, lti_user_id: @lti_user_id, context_id: @context_id),
+    build_payload(
+      client_id: @client_id,
+      iss: @iss,
+      lti_user_id: @lti_user_id,
+      context_id: @context_id,
+      message_type: @message_type,
+    ),
     jwk.private_key,
     jwk.alg,
     kid: jwk.kid,
@@ -69,11 +78,12 @@ def setup_lti_advantage_users
       user_id: @student.id,
       iss: @iss,
       deployment_id: @deployment_id,
+      context_id: @context_id,
     },
   )
 end
 
-def build_payload(client_id:, iss:, lti_user_id:, context_id:)
+def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
   exp = 24.hours.from_now
   nonce = SecureRandom.hex(10)
   {


### PR DESCRIPTION
If a user needed to authorize with Canvas before using the application, the application would fail with an internal server error after authorizing. If you refreshed the page, the application would launch correctly but not immediately after authorizing.

This was happening because the authorization flow wasn't setting some necessary LTI 1.3 values.

This branch adds those values and the application runs correctly after authorizing with Canvas. No page refresh needed.