### PR TITLE
Get the user id as a variable substitution

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,6 +125,7 @@ applications = [
       custom_fields: {
         canvas_course_id: "$Canvas.course.id",
         canvas_api_domain: "$Canvas.api.domain",
+        canvas_user_id: "$Canvas.user.id",
       },
       course_navigation: {
         text: "LTI Starter App",


### PR DESCRIPTION
While Canvas usually provides this for us without us needing to ask for it, in content item select launches it will not, resulting in users that temporarily do not have a lms user id until they launch normally.