### PR TITLE
If the student email is invalid they receive a 500 error

### DIFF
--- a/app/controllers/concerns/lti_support.rb
+++ b/app/controllers/concerns/lti_support.rb
@@ -101,6 +101,9 @@ module Concerns
     rescue ActiveRecord::RecordInvalid => ex
       if ex.to_s == "Validation failed: Email has already been taken"
         false
+      elsif ex.to_s == "Validation failed: Email is invalid"
+        # If email is invalid, i.e. bob@example, then just generate a random email
+        false
       else
         raise ex
       end

--- a/spec/controllers/concerns/lti_support_spec.rb
+++ b/spec/controllers/concerns/lti_support_spec.rb
@@ -178,6 +178,27 @@ describe ApplicationController, type: :controller do
           end
         end
       end
+
+      context "user has invalid email" do
+        before do
+          @role = "urn:lti:role:ims/lis/Instructor"
+          @email = "bob@example"
+          @params = lti_params(
+            @application_instance.lti_key,
+            @application_instance.lti_secret,
+            {
+              "launch_url" => @launch_url,
+              "roles" => @role,
+              "lis_person_contact_email_primary" => @email,
+            },
+          )
+        end
+        it "creates a user and does the LTI launch" do
+          post :index, params: @params
+          expect(response).to have_http_status(200)
+          expect(response.body).to include("User: Atomic Jolt")
+        end
+      end
     end
 
     context "invalid LTI request" do


### PR DESCRIPTION
We validate the email on an LTI request. We don't actually need a valid email. Bookshark put in all bogus emails and they weren't able to launch our tool. If we detect a bad email we just generate an anonymous value and move along. Everyone can be happy now.