### PR TITLE
Support Multiple LTI Installs with the Same `iss` 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :linter do
   gem "rubocop-rails"
 end
 
-group :development, :build, :ci do
+group :development, :build, :ci, :test do
   # Assets
   gem "sassc-rails"
 end

--- a/app/controllers/concerns/deep_linking.rb
+++ b/app/controllers/concerns/deep_linking.rb
@@ -13,7 +13,8 @@ module Concerns
       host:
     )
       platform_iss = token["iss"]
-      client_id = application_instance.application.client_id(platform_iss)
+      lti_deployment = LtiDeployment.find_by(deployment_id: token["deployment_id"])
+      client_id = lti_deployment.lti_install.client_id
 
       payload = {
         iss: client_id, # A unique identifier for the entity that issued the JWT

--- a/app/controllers/concerns/open_id_connect_support.rb
+++ b/app/controllers/concerns/open_id_connect_support.rb
@@ -13,7 +13,7 @@ module Concerns
         response_type: "id_token",
         redirect_uri: params[:target_link_uri],
         response_mode: "form_post",
-        client_id: current_application.client_id(params["iss"]),
+        client_id: params[:client_id],
         scope: "openid",
         state: state,
         login_hint: params[:login_hint],

--- a/app/controllers/concerns/open_id_connect_support.rb
+++ b/app/controllers/concerns/open_id_connect_support.rb
@@ -7,7 +7,7 @@ module Concerns
     def build_response(state, params, nonce)
       # The request doesn't contain any information to help us find the right application instance
       # so we have to use predefined URLs
-      uri = URI.parse(current_application.oidc_url(params["iss"]))
+      uri = URI.parse(current_application.oidc_url(params["iss"], params[:client_id]))
       uri_params = Rack::Utils.parse_query(uri.query)
       auth_params = {
         response_type: "id_token",

--- a/app/lib/lti_advantage/authorization.rb
+++ b/app/lib/lti_advantage/authorization.rb
@@ -14,7 +14,7 @@ module LtiAdvantage
       end
     end
 
-    # Validates a token provided by and LTI consumer
+    # Validates a token provided by an LTI consumer
     def self.validate_token(application_instance, token)
       # Get the iss value from the original request during the oidc call.
       # Use that value to figure out which jwk we should use.

--- a/app/lib/lti_advantage/authorization.rb
+++ b/app/lib/lti_advantage/authorization.rb
@@ -82,7 +82,11 @@ module LtiAdvantage
         "Content-Type" => "application/x-www-form-urlencoded",
       }
 
-      result = HTTParty.post(application_instance.token_url(lti_token["iss"]), body: body, headers: headers)
+      lti_deployment = LtiDeployment.find_by(
+        deployment_id: lti_token[LtiAdvantage::Definitions::DEPLOYMENT_ID],
+      )
+      client_id = lti_deployment.lti_install.client_id
+      result = HTTParty.post(application_instance.token_url(lti_token["iss"], client_id), body: body, headers: headers)
       authorization = JSON.parse(result.body)
 
       Rails.cache.write(cache_key, authorization, expires_in: authorization["expires_in"].to_i)

--- a/app/lib/lti_advantage/authorization.rb
+++ b/app/lib/lti_advantage/authorization.rb
@@ -29,7 +29,9 @@ module LtiAdvantage
             deployment_id: decoded_token.dig(0, LtiAdvantage::Definitions::DEPLOYMENT_ID),
           )
           client_id = lti_deployment.lti_install.client_id
-          jwks = JSON.parse(HTTParty.get(application_instance.application.jwks_url(iss, client_id)).body).deep_symbolize_keys
+          jwks = JSON.parse(
+            HTTParty.get(application_instance.application.jwks_url(iss, client_id)).body,
+          ).deep_symbolize_keys
           Rails.cache.write(cache_key, jwks, expires_in: 12.hours)
         end
         jwks
@@ -44,17 +46,19 @@ module LtiAdvantage
       JWT.encode(payload, jwk.private_key, jwk.alg, kid: jwk.kid, typ: "JWT")
     end
 
-    def self.client_assertion(application_instance, platform_iss)
+    def self.client_assertion(application_instance, lti_token)
       # https://www.imsglobal.org/spec/lti/v1p3/#token-endpoint-claim-and-services
       # When requesting an access token, the client assertion JWT iss and sub must both be the
       # OAuth 2 client_id of the tool as issued by the learning platform during registration.
       # Additional information:
       # https://www.imsglobal.org/spec/security/v1p0/#using-json-web-tokens-with-oauth-2-0-client-credentials-grant
-      client_id = application_instance.application.client_id(platform_iss)
+
+      lti_deployment = LtiDeployment.find_by(deployment_id: lti_token[LtiAdvantage::Definitions::DEPLOYMENT_ID])
+
       payload = {
         iss: application_instance.lti_key, # A unique identifier for the entity that issued the JWT
-        sub: client_id, # "client_id" of the OAuth Client
-        aud: application_instance.token_url(platform_iss), # Authorization server identifier
+        sub: lti_deployment.lti_install.client_id, # "client_id" of the OAuth Client
+        aud: lti_deployment.lti_install.token_url, # Authorization server identifier
         iat: Time.now.to_i, # Timestamp for when the JWT was created
         exp: Time.now.to_i + 300, # Timestamp for when the JWT should be treated as having expired
         # (after allowing a margin for clock skew)
@@ -76,7 +80,7 @@ module LtiAdvantage
         grant_type: "client_credentials",
         client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         scope: LtiAdvantage::Definitions.scopes.join(" "),
-        client_assertion: client_assertion(application_instance, lti_token["iss"]),
+        client_assertion: client_assertion(application_instance, lti_token),
       }
       headers = {
         "Content-Type" => "application/x-www-form-urlencoded",

--- a/app/lib/lti_advantage/authorization.rb
+++ b/app/lib/lti_advantage/authorization.rb
@@ -25,7 +25,11 @@ module LtiAdvantage
       jwk_loader = ->(options) do
         jwks = Rails.cache.read(cache_key)
         if options[:invalidate] || jwks.blank?
-          jwks = JSON.parse(HTTParty.get(application_instance.application.jwks_url(iss)).body).deep_symbolize_keys
+          lti_deployment = LtiDeployment.find_by(
+            deployment_id: decoded_token.dig(0, LtiAdvantage::Definitions::DEPLOYMENT_ID),
+          )
+          client_id = lti_deployment.lti_install.client_id
+          jwks = JSON.parse(HTTParty.get(application_instance.application.jwks_url(iss, client_id)).body).deep_symbolize_keys
           Rails.cache.write(cache_key, jwks, expires_in: 12.hours)
         end
         jwks

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -59,24 +59,20 @@ class Application < ApplicationRecord
     jwks.create!
   end
 
-  def oidc_url(iss)
-    lti_install_for(iss).oidc_url
+  def oidc_url(iss, client_id)
+    lti_install_for(iss, client_id).oidc_url
   end
 
-  def token_url(iss)
-    lti_install_for(iss).token_url
+  def token_url(iss, client_id)
+    lti_install_for(iss, client_id).token_url
   end
 
-  def jwks_url(iss)
-    lti_install_for(iss).jwks_url
+  def jwks_url(iss, client_id)
+    lti_install_for(iss, client_id).jwks_url
   end
 
-  def client_id(iss)
-    lti_install_for(iss).client_id
-  end
-
-  def lti_install_for(iss)
-    if lti_install = lti_installs.find_by(iss: iss)
+  def lti_install_for(iss, client_id)
+    if lti_install = lti_installs.find_by(iss: iss, client_id: client_id)
       lti_install
     else
       raise LtiAdvantage::Exceptions::ConfigurationError,

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -110,8 +110,8 @@ class ApplicationInstance < ApplicationRecord
     "#{canvas_token.first(4)}...#{canvas_token.last(4)}"
   end
 
-  def token_url(iss)
-    url = application.token_url(iss)
+  def token_url(iss, client_id)
+    url = application.token_url(iss, client_id)
 
     # The Canvas token endpoint is customer specific. i.e. https://atomicjolt.instructure.com
     # We can get that value from the site associated with the application instance

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -55,7 +55,11 @@ class ApplicationInstance < ApplicationRecord
         # Create a new application instance and lti_deployment
         lti_key = "#{site.key}-#{lti_install.application.key}-#{deployment_id}"
         application_instance = lti_install.application.create_instance(site: site, lti_key: lti_key)
-        application_instance.lti_deployments.create!(deployment_id: deployment_id)
+        LtiDeployment.create!(
+          application_instance: application_instance,
+          lti_install: lti_install,
+          deployment_id: deployment_id,
+        )
       end
 
       application_instance

--- a/app/models/lti_deployment.rb
+++ b/app/models/lti_deployment.rb
@@ -1,5 +1,7 @@
 class LtiDeployment < ApplicationRecord
   belongs_to :application_instance
+  belongs_to :lti_install
+
   validates :application_instance_id, presence: true
   validates :deployment_id, presence: true, uniqueness: { scope: %i[application_instance_id] }
 end

--- a/app/models/lti_install.rb
+++ b/app/models/lti_install.rb
@@ -1,5 +1,7 @@
 class LtiInstall < ApplicationRecord
   belongs_to :application
+  has_many :lti_deployments, dependent: :restrict_with_exception
+
   validates :application_id, presence: true
   validates :client_id, presence: true, uniqueness: { scope: %i[iss] }
 end

--- a/db/migrate/20200624153201_add_lti_install_id_to_lti_deployments.rb
+++ b/db/migrate/20200624153201_add_lti_install_id_to_lti_deployments.rb
@@ -1,0 +1,5 @@
+class AddLtiInstallIdToLtiDeployments < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :lti_deployments, :lti_install, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_194920) do
+ActiveRecord::Schema.define(version: 2020_06_24_153201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,9 +166,11 @@ ActiveRecord::Schema.define(version: 2020_02_26_194920) do
     t.string "deployment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "lti_install_id"
     t.index ["application_instance_id"], name: "index_lti_deployments_on_application_instance_id"
     t.index ["deployment_id", "application_instance_id"], name: "index_lti_deployments_on_d_id_and_ai_id", unique: true
     t.index ["deployment_id"], name: "index_lti_deployments_on_deployment_id"
+    t.index ["lti_install_id"], name: "index_lti_deployments_on_lti_install_id"
   end
 
   create_table "lti_installs", force: :cascade do |t|
@@ -301,4 +303,5 @@ ActiveRecord::Schema.define(version: 2020_02_26_194920) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "lti_deployments", "lti_installs"
 end

--- a/spec/controllers/concerns/open_id_connect_support_spec.rb
+++ b/spec/controllers/concerns/open_id_connect_support_spec.rb
@@ -28,9 +28,11 @@ describe ApplicationController, type: :controller do
       request.env["CONTENT_TYPE"] = "application/x-www-form-urlencoded"
       setup_canvas_lti_advantage(application_instance: @application_instance)
     end
+
     it "get a url that will be redirected to as part of the Open Id Connect process" do
       params = {
         "iss" => @iss,
+        "client_id" => @client_id,
         "login_hint" => "0340cde37624c04979a6c3fdd0afc2479f8405ad",
         "target_link_uri" => "https://helloworld.atomicjolt.xyz/lti_launches",
         "lti_message_hint" => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJpZmllciI6IjI5M2NlNDI4MjM3ZTAyNTc5MDg3ZmVkOTU5M2EwYzFmMDVmYmNhOTZhNTU3YjQyYjNiOWJiZmIwNTE4MDM4NmQwYzA5NjdmM2FhZDdhYzczODc4Yjk1YjM4NWJmMDVhNDU4MTBmZGZmYzNiMThmZDA5ZWY5YjMyOTUzZjNiOWUwIiwiY2FudmFzX2RvbWFpbiI6ImF0b21pY2pvbHQuaW5zdHJ1Y3R1cmUuY29tIiwiY29udGV4dF90eXBlIjoiQ291cnNlIiwiY29udGV4dF9pZCI6NDM0NjAwMDAwMDAwMDMzMzQsImV4cCI6MTU2MzQwNzk5OX0.7y8ZqEz4zwGvaBUV8puXCIINxnCulRGRg58jExPAhTo",

--- a/spec/controllers/lti_launches_controller_spec.rb
+++ b/spec/controllers/lti_launches_controller_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe LtiLaunchesController, type: :controller do
     it "get a url that will be redirected to as part of the Open Id Connect process" do
       params = {
         "iss" => @iss,
+        "client_id" => @client_id,
         "login_hint" => "0340cde37624c04979a6c3fdd0afc2479f8405ad",
         "target_link_uri" => "https://helloworld.atomicjolt.xyz/lti_launches",
         "lti_message_hint" => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJpZmllciI6IjI5M2NlNDI4MjM3ZTAyNTc5MDg3ZmVkOTU5M2EwYzFmMDVmYmNhOTZhNTU3YjQyYjNiOWJiZmIwNTE4MDM4NmQwYzA5NjdmM2FhZDdhYzczODc4Yjk1YjM4NWJmMDVhNDU4MTBmZGZmYzNiMThmZDA5ZWY5YjMyOTUzZjNiOWUwIiwiY2FudmFzX2RvbWFpbiI6ImF0b21pY2pvbHQuaW5zdHJ1Y3R1cmUuY29tIiwiY29udGV4dF90eXBlIjoiQ291cnNlIiwiY29udGV4dF9pZCI6NDM0NjAwMDAwMDAwMDMzMzQsImV4cCI6MTU2MzQwNzk5OX0.7y8ZqEz4zwGvaBUV8puXCIINxnCulRGRg58jExPAhTo",

--- a/spec/factories/_common.rb
+++ b/spec/factories/_common.rb
@@ -103,6 +103,14 @@ FactoryBot.define do
     "123aba321_#{n}"
   end
 
+  sequence :client_id do |n|
+    "1200000#{n}"
+  end
+
+  sequence :deployment_id do |n|
+    "#{SecureRandom.hex}#{n}"
+  end
+
   sequence :user_id do |n|
     n
   end

--- a/spec/factories/lti_deployments.rb
+++ b/spec/factories/lti_deployments.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :lti_deployment do
+    lti_install
   end
 end

--- a/spec/factories/lti_deployments.rb
+++ b/spec/factories/lti_deployments.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :lti_deployment do
+    application_instance
     lti_install
+    deployment_id { FactoryBot.generate(:deployment_id) }
   end
 end

--- a/spec/factories/lti_installs.rb
+++ b/spec/factories/lti_installs.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :lti_install do
-    client_id { generate(:lti_key) }
+    application
+    client_id { generate(:client_id) }
   end
 end

--- a/spec/lib/lti_advantage/authorization_spec.rb
+++ b/spec/lib/lti_advantage/authorization_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe LtiAdvantage::Authorization do
 
   describe "client_assertion" do
     it "generates a token that can be passed to the platform to request and access token" do
-      jwt = LtiAdvantage::Authorization.client_assertion(@application_instance, @platform_iss)
+      decoded_token = LtiAdvantage::Authorization.validate_token(@application_instance, @id_token)
+      jwt = LtiAdvantage::Authorization.client_assertion(@application_instance, decoded_token)
       expect(jwt).to be
       decoded_token = JWT.decode(jwt, nil, false)[0]
       expect(decoded_token["iss"]).to eq @application_instance.lti_key

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -21,4 +21,51 @@ RSpec.describe Application, type: :model do
       expect(application.valid?).to be false
     end
   end
+
+  describe "LtiInstall attribute getter methods" do
+    let(:application) { FactoryBot.create(:application) }
+    let(:iss) { FactoryBot.generate(:url) }
+    let(:client_id) { FactoryBot.generate(:client_id) }
+    let(:oidc_url) { FactoryBot.generate(:url) }
+    let(:token_url) { FactoryBot.generate(:url) }
+    let(:jwks_url) { FactoryBot.generate(:url) }
+
+    before do
+      @lti_install = FactoryBot.create(
+        :lti_install,
+        application: application,
+        iss: iss,
+        client_id: client_id,
+        oidc_url: oidc_url,
+        token_url: token_url,
+        jwks_url: jwks_url,
+      )
+
+      FactoryBot.create(:lti_install, application: application, iss: iss)
+    end
+
+    describe "#oidc_url" do
+      it "returns the correct oidc_url" do
+        result = application.oidc_url(iss, client_id)
+
+        expect(result).to eq(oidc_url)
+      end
+    end
+
+    describe "#token_url" do
+      it "returns the correct token_url" do
+        result = application.token_url(iss, client_id)
+
+        expect(result).to eq(token_url)
+      end
+    end
+
+    describe "#jwks_url" do
+      it "returns the correct jwks_url" do
+        result = application.jwks_url(iss, client_id)
+
+        expect(result).to eq(jwks_url)
+      end
+    end
+  end
 end

--- a/spec/models/ims_export_spec.rb
+++ b/spec/models/ims_export_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe ImsExport, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/lti_deployment_spec.rb
+++ b/spec/models/lti_deployment_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe LtiDeployment, type: :model do
   before do
     @application_instance = FactoryBot.create(:application_instance)
+    @lti_install = FactoryBot.create(:lti_install)
   end
 
   it "validates application instance" do
@@ -18,6 +19,7 @@ RSpec.describe LtiDeployment, type: :model do
   it "creates an lti deployment" do
     lti_deployment = LtiDeployment.new(
       application_instance: @application_instance,
+      lti_install: @lti_install,
       deployment_id: "test",
     )
     expect(lti_deployment.valid?).to be true

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -26,6 +26,7 @@ def setup_canvas_lti_advantage(
 
   application_instance.lti_deployments.create!(
     deployment_id: @deployment_id,
+    lti_install: application_instance.application.lti_installs.last,
   )
 
   jwk = application_instance.application.current_jwk

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -1,6 +1,6 @@
 def setup_canvas_lti_advantage(
   application_instance:,
-  client_id: rand(1..99999).to_s,
+  client_id: FactoryBot.generate(:client_id),
   iss: "https://canvas.instructure.com",
   lti_user_id: SecureRandom.uuid,
   context_id: SecureRandom.hex(15),


### PR DESCRIPTION
## Goal
Currently, the application has some incorrect logic that doesn't allow having multiple `LtiInstall` records with the same `iss`. When there are two `LtiInstall` records with the same `iss`, the most recent `LtiInstall` record's `client_id` is always used. This means that only deployments associated with the most recent `LtiInstall` with that `iss` can be launched or embedded. This branch makes the necessary changes to allow multiple `LtiInstall`s with the same `iss`.

## Implementation Details
We addressed the above problem by making the `LtiDeployment` model a child of `LtiInstall`. This will give us access to the `client_id` in a few different contexts where we need it. Right now, we're finding the `client_id` by looking up the `LtiInstall` with the `iss`. This isn't a dependable way to get a `client_id` though because there may be multiple `LtiInstall` records with the same `iss`. Associating an `LtiDeployment` with an `LtiInstall` will give us a dependable way to determine the correct client ID in those contexts where we need it.

Making `LtiDeployment` a child of `LtiInstall` also makes sense conceptually; we create an `LtiDeployment` based on a given `LtiInstall`.

---------------------------------

## After Creating the Pull Request

* [ ] Ensure CI passes.
* [ ] Mark pull request as ready to review.
* [ ] Request reviews.
* [ ] Remember to include PR description in merge commit body.
