### PR TITLE
Added error message for when LTI key is set to private

### DIFF
--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -44,11 +44,8 @@ module LtiAdvantage
           members = JSON.parse(names_and_roles_memberships.body)["members"]
 
           if members.present? && members.all? { |member| member["name"].nil? }
-            raise(
-              GraphQL::ExecutionError,
-              "Unable to fetch learner data. Your LTI key may be set to private.
-                Please set it to public to view reports.",
-            )
+            throw LtiAdvantage::Exceptions::NamesAndRolesError, "Unable to fetch learner data.
+            Your LTI key may be set to private. Please set it to public to view reports."
           end
         end
         names_and_roles_memberships

--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -26,14 +26,32 @@ module LtiAdvantage
       def list(query = nil)
         url = endpoint.dup
         url << "?#{query}" if query.present?
-        HTTParty.get(
-          url,
-          headers: headers(
-            {
-              "Content-Type" => "application/vnd.ims.lti-nrps.v2.membershipcontainer+json",
-            },
+
+        verify_received_learner_names(
+          HTTParty.get(
+            url,
+            headers: headers(
+              {
+                "Content-Type" => "application/vnd.ims.lti-nrps.v2.membershipcontainer+json",
+              },
+            ),
           ),
         )
+      end
+
+      def verify_received_learner_names(names_and_roles_memberships)
+        if names_and_roles_memberships.present?
+          members = JSON.parse(names_and_roles_memberships.body)["members"]
+
+          if members.present? && members.all? { |member| member["name"].nil? }
+            raise(
+              GraphQL::ExecutionError,
+              "Unable to fetch learner data. Your LTI key may be set to private.
+                Please set it to public to view reports.",
+            )
+          end
+        end
+        names_and_roles_memberships
       end
     end
   end


### PR DESCRIPTION
This gives an error message when the names and roles list is called and the LTI key is set to private.