### PR TITLE
lti params helper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,6 +179,7 @@ class ApplicationController < ActionController::Base
       current_application_instance,
       params[:id_token],
     )
+    @lti_params = LtiAdvantage::Params.new(@lti_token)
     @lti_launch_config = JSON.parse(params[:lti_launch_config]) if params[:lti_launch_config]
     @is_deep_link = true if LtiAdvantage::Definitions.deep_link_launch?(@lti_token)
     @app_name = current_application_instance.application.client_application_name

--- a/app/lib/lti_advantage/definitions.rb
+++ b/app/lib/lti_advantage/definitions.rb
@@ -47,6 +47,10 @@ module LtiAdvantage
     MENTOR_SCOPE = "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor".freeze
     MENTOR_ROLE_SCOPE = "a62c52c02ba262003f5e".freeze
 
+    # Launch contexts
+    COURSE_CONTEXT = "http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering".freeze
+    ACCOUNT_CONTEXT = "Account".freeze
+
     # Specfies all available scopes.
     def self.scopes
       [

--- a/app/lib/lti_advantage/params.rb
+++ b/app/lib/lti_advantage/params.rb
@@ -10,12 +10,13 @@ module LtiAdvantage
     def launch_context
       # This is an array, I'm not sure what it means to have more than one
       # value. In courses and accounts there's only one value
-      context = context_data["type"][0]
-
-      case context
-      when LtiAdvantage::Definitions::COURSE_CONTEXT then "COURSE"
-      when LtiAdvantage::Definitions::ACCOUNT_CONTEXT then "ACCOUNT"
-      else "UNKNOWN"
+      contexts = context_data["type"] || []
+      if contexts.include? LtiAdvantage::Definitions::COURSE_CONTEXT
+        "COURSE"
+      elsif contexts.include? LtiAdvantage::Definitions::ACCOUNT_CONTEXT
+        "ACCOUNT"
+      else
+        "UNKNOWN"
       end
     end
 
@@ -24,7 +25,7 @@ module LtiAdvantage
     end
 
     def context_data
-      token[LtiAdvantage::Definitions::CONTEXT_CLAIM]
+      token[LtiAdvantage::Definitions::CONTEXT_CLAIM] || {}
     end
 
     def course_id
@@ -52,7 +53,7 @@ module LtiAdvantage
     # These values must be added to the developer key under "Custom Fields"
     # for example: canvas_course_id=$Canvas.course.id
     def custom_params
-      token[LtiAdvantage::Definitions::CUSTOM_CLAIM]
+      token[LtiAdvantage::Definitions::CUSTOM_CLAIM] || {}
     end
   end
 end

--- a/app/lib/lti_advantage/params.rb
+++ b/app/lib/lti_advantage/params.rb
@@ -1,0 +1,58 @@
+module LtiAdvantage
+  # This is for extracting data from the lti jwt in more human-readable ways
+  class Params
+    attr_reader :token
+
+    def initialize(lti_token)
+      @token = lti_token
+    end
+
+    def launch_context
+      # This is an array, I'm not sure what it means to have more than one
+      # value. In courses and accounts there's only one value
+      context = context_data["type"][0]
+
+      case context
+      when LtiAdvantage::Definitions::COURSE_CONTEXT then "COURSE"
+      when LtiAdvantage::Definitions::ACCOUNT_CONTEXT then "ACCOUNT"
+      else "UNKNOWN"
+      end
+    end
+
+    def context_id
+      context_data["id"]
+    end
+
+    def context_data
+      token[LtiAdvantage::Definitions::CONTEXT_CLAIM]
+    end
+
+    def course_id
+      value = custom_params["canvas_course_id"]
+      if value != "$Canvas.course.id"
+        value
+      end
+    end
+
+    def account_id
+      value = custom_params["canvas_account_id"]
+      if value != "$Canvas.account.id"
+        value
+      end
+    end
+
+    def course_name
+      value = custom_params["canvas_course_name"]
+      if value != "$Canvas.course.name"
+        value
+      end
+    end
+
+    # This extracts the custom parameters from the jwt token from the lti launch
+    # These values must be added to the developer key under "Custom Fields"
+    # for example: canvas_course_id=$Canvas.course.id
+    def custom_params
+      token[LtiAdvantage::Definitions::CUSTOM_CLAIM]
+    end
+  end
+end

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -36,10 +36,13 @@
     # Adds LTI Advantage values to settings
     @lti_advantage_examples.add_to_settings(settings) if @lti_advantage_examples.present?
 
-    if params["id_token"].present?
+    if lti_advantage?
       # LTI 1.3 Launch
       settings[:id_token] = params["id_token"]
-      settings[:context_id] = @lti_token.dig(LtiAdvantage::Definitions::CONTEXT_CLAIM)["id"]
+      settings[:context_id] = @lti_params.context_id
+      settings[:canvas_course_id] = @lti_params.course_id
+      settings[:canvas_account_id] = @lti_params.account_id
+      settings[:launch_context] = @lti_params.launch_context
     elsif @is_lti_launch
       # LTI 1.0 - 1.2 Launch
       settings[:oauth_consumer_key]                     = params[:oauth_consumer_key]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -270,7 +270,7 @@ def setup_application_instances(application, application_instances)
       else
         lti_install = application_instance.application.lti_installs.find_by(iss: "https://canvas.instructure.com")
         application_instance.lti_deployments.create!(
-          lti_deployment_attr.merge(lti_install: lti_install)
+          lti_deployment_attr.merge(lti_install: lti_install),
         )
       end
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -268,7 +268,10 @@ def setup_application_instances(application, application_instances)
       if found = application_instance.lti_deployments.find_by(deployment_id: lti_deployment_attr[:deployment_id])
         found.update_attributes!(lti_deployment_attr)
       else
-        application_instance.lti_deployments.create!(lti_deployment_attr)
+        lti_install = application_instance.application.lti_installs.find_by(iss: "https://canvas.instructure.com")
+        application_instance.lti_deployments.create!(
+          lti_deployment_attr.merge(lti_install: lti_install)
+        )
       end
     end
 
@@ -308,7 +311,6 @@ if Apartment::Tenant.current == "public"
       puts "Creating application: #{attrs[:name]}"
       application = Application.create!(attrs)
     end
-    setup_application_instances(application, application_instances)
 
     lti_installs_attrs&.each do |lti_install_attrs|
       if lti_install = application.lti_installs.find_by(
@@ -320,6 +322,8 @@ if Apartment::Tenant.current == "public"
         application.lti_installs.create!(lti_install_attrs)
       end
     end
+
+    setup_application_instances(application, application_instances)
   end
 
   bundles.each do |attrs|


### PR DESCRIPTION
    makes a couple of improvements to lti advantage param handling.
    1) It adds a class that wraps the params we receive from Canvas and
       provies convenience methods for accessing different pieces of data.
    2) Both the oauth and lti launch controllers now call a
       set_lti_advantage_launch_values method for setting instance variables
       based on the launch params.
    3) Adds a simple helper function to check if the current launch is lti
       advatage, rather than repeating the id_token check, which is less
       obvious

Also fixes the seeds, which were broken