### PR TITLE
Fix Console Errors

### DIFF
--- a/client/apps/hello_world/styles/modules/_mixins.scss
+++ b/client/apps/hello_world/styles/modules/_mixins.scss
@@ -2,8 +2,8 @@
 // That's why the urls includes/ fonts/ even though that is up one directory
 @font-face {
   font-family: "robotobold";
-  src: url("/fonts/roboto-bold-webfont.woff2") format("woff2"),
-       url("/fonts/roboto-bold-webfont.woff") format("woff");
+  src: url("fonts/roboto-bold-webfont.woff2") format("woff2"),
+       url("fonts/roboto-bold-webfont.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 
@@ -11,8 +11,8 @@
 
 @font-face {
   font-family: "robotoregular";
-  src: url("/fonts/roboto-regular-webfont.woff2") format("woff2"),
-       url("/fonts/roboto-regular-webfont.woff") format("woff");
+  src: url("fonts/roboto-regular-webfont.woff2") format("woff2"),
+       url("fonts/roboto-regular-webfont.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }

--- a/client/apps/hello_world_graphql/components/home.spec.jsx
+++ b/client/apps/hello_world_graphql/components/home.spec.jsx
@@ -10,6 +10,7 @@ const mocks = [
   {
     request: {
       query: GET_WELCOME,
+      variables: { name: 'World' },
     },
     result: {
       data: {

--- a/client/apps/hello_world_graphql/history.js
+++ b/client/apps/hello_world_graphql/history.js
@@ -1,3 +1,3 @@
-import createHashHistory from 'history/createHashHistory';
+import { createHashHistory } from 'history';
 
 export default createHashHistory();

--- a/client/apps/hello_world_graphql/styles/modules/_mixins.scss
+++ b/client/apps/hello_world_graphql/styles/modules/_mixins.scss
@@ -2,8 +2,8 @@
 // That's why the urls includes /fonts/ even though that is up one directory
 @font-face {
   font-family: "robotobold";
-  src: url("/fonts/roboto-bold-webfont.woff2") format("woff2"),
-       url("/fonts/roboto-bold-webfont.woff") format("woff");
+  src: url("fonts/roboto-bold-webfont.woff2") format("woff2"),
+       url("fonts/roboto-bold-webfont.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 
@@ -11,8 +11,8 @@
 
 @font-face {
   font-family: "robotoregular";
-  src: url("/fonts/roboto-regular-webfont.woff2") format("woff2"),
-       url("/fonts/roboto-regular-webfont.woff") format("woff");
+  src: url("fonts/roboto-regular-webfont.woff2") format("woff2"),
+       url("fonts/roboto-regular-webfont.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module ReactRailsStarterApp
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
-    config.action_dispatch.default_headers = {}
+    config.action_dispatch.default_headers.delete("X-Frame-Options")
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,9 +23,7 @@ module ReactRailsStarterApp
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
-    config.action_dispatch.default_headers = {
-      "X-Frame-Options" => "ALLOWALL",
-    }
+    config.action_dispatch.default_headers = {}
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do


### PR DESCRIPTION
This branch updates a few issues that are causing errors to be displayed in the browser console:
* Eliminate invalid "X-Frame-Options" header
* Update deprecated `createHashHistory` import
* Fix incorrect path to fonts

Please see the individual commit messages for more details on each fix.