### PR TITLE
Update default mailer url host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,7 +111,9 @@ Rails.application.configure do
   # }
 
   # ActionMailer Config
-  config.action_mailer.default_url_options = { host: Rails.application.secrets.application_root_domain }
+  config.action_mailer.default_url_options = {
+    host: "#{Application::ADMIN}.#{Rails.application.secrets.application_root_domain}",
+  }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Use admin subdomain so invitations have the correct url to setup your
account with.