### PR TITLE
Improve LTI Key Error

### DIFF
--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -44,8 +44,11 @@ module LtiAdvantage
           members = JSON.parse(names_and_roles_memberships.body)["members"]
 
           if members.present? && members.all? { |member| member["name"].nil? }
-            raise LtiAdvantage::Exceptions::NamesAndRolesError, "Unable to fetch learner data.
-            Your LTI key may be set to private. Please set it to public to view reports."
+            raise(
+              LtiAdvantage::Exceptions::NamesAndRolesError,
+              "Unable to fetch learner data. Your LTI key may be set to private. " \
+                "Please set it to public to view reports.",
+            )
           end
         end
         names_and_roles_memberships

--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -44,7 +44,7 @@ module LtiAdvantage
           members = JSON.parse(names_and_roles_memberships.body)["members"]
 
           if members.present? && members.all? { |member| member["name"].nil? }
-            throw LtiAdvantage::Exceptions::NamesAndRolesError, "Unable to fetch learner data.
+            raise LtiAdvantage::Exceptions::NamesAndRolesError, "Unable to fetch learner data.
             Your LTI key may be set to private. Please set it to public to view reports."
           end
         end

--- a/spec/lib/lti_advantage/services/names_and_roles_spec.rb
+++ b/spec/lib/lti_advantage/services/names_and_roles_spec.rb
@@ -33,5 +33,33 @@ RSpec.describe LtiAdvantage::Services::NamesAndRoles do
         anything,
       )
     end
+
+    context "when it looks like the LTI key is set to private" do
+      before do
+        allow(HTTParty).to receive(:get).and_return(
+          OpenStruct.new(
+            {
+              body: {
+                "members": [
+                  { "status" => "Active", "user_id" => "1", "roles" => ["learner"] },
+                  { "status" => "Active", "user_id" => "2", "roles" => ["learner"] },
+                ],
+              }.to_json,
+            },
+          ),
+        )
+      end
+
+      it "raises an exception with a helpful error message" do
+        names_and_roles_service = LtiAdvantage::Services::NamesAndRoles.new(@application_instance, @lti_token)
+
+        expect do
+          names_and_roles_service.list
+        end.to raise_exception(
+          LtiAdvantage::Exceptions::NamesAndRolesError,
+          "Unable to fetch learner data. Your LTI key may be set to private. Please set it to public to view reports.",
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This branch just makes a couple of improvements to the error we raise when it looks like the user's LTI key is set to private.