### PR TITLE
Improve Wording in Names and Roles Service

### DIFF
--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -27,7 +27,7 @@ module LtiAdvantage
         url = endpoint.dup
         url << "?#{query}" if query.present?
 
-        verify_received_learner_names(
+        verify_received_user_names(
           HTTParty.get(
             url,
             headers: headers(
@@ -39,14 +39,14 @@ module LtiAdvantage
         )
       end
 
-      def verify_received_learner_names(names_and_roles_memberships)
+      def verify_received_user_names(names_and_roles_memberships)
         if names_and_roles_memberships.present?
           members = JSON.parse(names_and_roles_memberships.body)["members"]
 
           if members.present? && members.all? { |member| member["name"].nil? }
             raise(
               LtiAdvantage::Exceptions::NamesAndRolesError,
-              "Unable to fetch learner data. Your LTI key may be set to private. " \
+              "Unable to fetch user data. Your LTI key may be set to private. " \
                 "Please set it to public to view reports.",
             )
           end

--- a/app/lib/lti_advantage/services/names_and_roles.rb
+++ b/app/lib/lti_advantage/services/names_and_roles.rb
@@ -46,8 +46,7 @@ module LtiAdvantage
           if members.present? && members.all? { |member| member["name"].nil? }
             raise(
               LtiAdvantage::Exceptions::NamesAndRolesError,
-              "Unable to fetch user data. Your LTI key may be set to private. " \
-                "Please set it to public to view reports.",
+              "Unable to fetch user data. Your LTI key may be set to private.",
             )
           end
         end

--- a/spec/lib/lti_advantage/services/names_and_roles_spec.rb
+++ b/spec/lib/lti_advantage/services/names_and_roles_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe LtiAdvantage::Services::NamesAndRoles do
           names_and_roles_service.list
         end.to raise_exception(
           LtiAdvantage::Exceptions::NamesAndRolesError,
-          "Unable to fetch learner data. Your LTI key may be set to private. Please set it to public to view reports.",
+          "Unable to fetch user data. Your LTI key may be set to private. Please set it to public to view reports.",
         )
       end
     end

--- a/spec/lib/lti_advantage/services/names_and_roles_spec.rb
+++ b/spec/lib/lti_advantage/services/names_and_roles_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe LtiAdvantage::Services::NamesAndRoles do
           names_and_roles_service.list
         end.to raise_exception(
           LtiAdvantage::Exceptions::NamesAndRolesError,
-          "Unable to fetch user data. Your LTI key may be set to private. Please set it to public to view reports.",
+          "Unable to fetch user data. Your LTI key may be set to private.",
         )
       end
     end


### PR DESCRIPTION
We recently added some code the the names and roles class that we extracted from Atomic Journals. We failed to generalize that code fully though and some of the naming and messaging was specific to Atomic Journals; it didn't make sense in the general context of the starter app.

This branch modifies and removes that out of place wording.