### PR TITLE
Add ability to display custom error message on 500 page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   def render_error(status, message, json_options = {})
     respond_to do |format|
-      format.html { render file: "public/#{status}.html", status: status }
+      format.html { render template: "errors/#{status}", layout: "errors", status: status }
       format.json do
         render json: {
           message: message,

--- a/app/models/application_instance.rb
+++ b/app/models/application_instance.rb
@@ -27,6 +27,7 @@ class ApplicationInstance < ApplicationRecord
   # Or instance.bar
   # If foo is not set in the config json, it will return nil
   # store_accessor :config, :foo, :bar
+  store_accessor :config, :custom_error_message
 
   attr_encrypted :canvas_token, key: Rails.application.secrets.encryption_key, mode: :per_attribute_iv_and_salt
 

--- a/app/views/errors/400.html.erb
+++ b/app/views/errors/400.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+Bad Request (400)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>Bad Request.</h1>
+  </div>
+</div>

--- a/app/views/errors/401.html.erb
+++ b/app/views/errors/401.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+Access denied (401)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>You are not authorized to access the requested page.</h1>
+  </div>
+</div>

--- a/app/views/errors/403.html.erb
+++ b/app/views/errors/403.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+Forbidden (403)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>You don't have permission to access the requested page.</h1>
+  </div>
+</div>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+The page you were looking for doesn't exist (404)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>The page you were looking for doesn't exist.</h1>
+    <p>You may have mistyped the address or the page may have moved.</p>
+  </div>
+  <p>If you are the application owner check the logs for more information.</p>
+</div>

--- a/app/views/errors/422.html.erb
+++ b/app/views/errors/422.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+The change you wanted was rejected (422)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>The change you wanted was rejected.</h1>
+    <p>Maybe you tried to change something you didn't have access to.</p>
+  </div>
+  <p>If you are the application owner check the logs for more information.</p>
+</div>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+We're sorry, but something went wrong (500)
+<% end %>
+
+<div class="dialog">
+  <div>
+    <h1>We're sorry, but something went wrong.</h1>
+    <div><%= current_application_instance&.custom_error_message %></div>
+  </div>
+  <p>If you are the application owner check the logs for more information.</p>
+</div>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for?(:title) ? yield(:title) : Rails.application.secrets.application_name %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+      body {
+        background-color: #EFEFEF;
+        color: #2E2F30;
+        text-align: center;
+        font-family: arial, sans-serif;
+        margin: 0;
+      }
+
+      div.dialog {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+      }
+
+      div.dialog > div {
+        border: 1px solid #CCC;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #BBB;
+        border-top: #B00100 solid 4px;
+        border-top-left-radius: 9px;
+        border-top-right-radius: 9px;
+        background-color: white;
+        padding: 7px 12% 0;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+
+      h1 {
+        font-size: 100%;
+        color: #730E15;
+        line-height: 1.5em;
+      }
+
+      div.dialog > p {
+        margin: 0 0 1em;
+        padding: 1em;
+        background-color: #F7F7F7;
+        border: 1px solid #CCC;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #999;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top-color: #DADADA;
+        color: #666;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <%= yield %>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Copy all error pages into views. Customize 500 page to add an optional custom error message.
Leaving public error pages intact. As they can still be used (like routing errors).