### PR TITLE
Let Rails handle 500 errors. 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   rescue_from Exception, with: :internal_error
   def internal_error(exception)
     record_exception(exception)
-    render_error 500, "Internal error: #{exception.message}"
+    raise exception
   end
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found


### PR DESCRIPTION
When dealing with a general exception Rails will handle returning the proper error. Just raise an exception or else you will end up with a "double render" error which masks the real error.