### PR TITLE
updated nginx ssl syntax

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -21,10 +21,9 @@ bin/bootstrap
 # Create config file for the app / site.
 cat > "/usr/local/etc/nginx/servers/${APP_SUBDOMAIN}.conf" <<-EOF
 server {
-    listen *:443;
+    listen *:443 ssl;
     server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -58,10 +57,9 @@ server {
 
 server {
 
-    listen *:443;
+    listen *:443 ssl;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -94,10 +92,9 @@ then
 
 server {
 
-  listen *:443;
+  listen *:443 ssl;
   server_name ${SUBDOMAIN}.atomicjolt.xyz;
 
-  ssl on;
   ssl_session_cache         builtin:1000  shared:SSL:10m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;

--- a/bin/setup-linux
+++ b/bin/setup-linux
@@ -23,10 +23,9 @@ echo "Run bin/bootstrap separately, not using sudo"
 # Create config file for the app / site.
 cat > "/etc/nginx/sites-available/${APP_SUBDOMAIN}.conf" <<-EOF
 server {
-    listen *:443;
+    listen *:443 ssl;
     server_name ${ASSETS_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -60,10 +59,9 @@ server {
 
 server {
 
-    listen *:443;
+    listen *:443 ssl;
     server_name ${APP_SUBDOMAIN}.atomicjolt.xyz;
 
-    ssl on;
     ssl_session_cache         builtin:1000  shared:SSL:10m;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
@@ -96,10 +94,9 @@ then
 
 server {
 
-  listen *:443;
+  listen *:443 ssl;
   server_name ${SUBDOMAIN}.atomicjolt.xyz;
 
-  ssl on;
   ssl_session_cache         builtin:1000  shared:SSL:10m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
nginx deprecated the `ssl on;` directive in favor of `listen *443 ... ssl`, this PR updates those in the setup and setup-linux scripts