### PR TITLE
Add Definition for Custom Exception Class

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -9,4 +9,6 @@ module Exceptions
   end
   class CanvasApiTokenRequired < LMS::Canvas::CanvasException
   end
+  class UnAuthorizedGraphQLCanvasRequest < GraphQL::ExecutionError
+  end
 end


### PR DESCRIPTION
In `app/controllers/api/graphql_controller.rb` on line 24, we raise an `Exceptions::UnAuthorizedGraphQLCanvasRequest` error. However, this exception class isn't defined.