### PR TITLE
Store Resource Link ID in LTI Launch Record 

### DIFF
--- a/app/controllers/lti_launches_controller.rb
+++ b/app/controllers/lti_launches_controller.rb
@@ -13,10 +13,19 @@ class LtiLaunchesController < ApplicationController
       render file: File.join(Rails.root, "public", "disabled.html")
     end
 
-    # LTI advantage example code
     if @lti_token
+      # LTI advantage example code
       @lti_advantage_examples = LtiAdvantage::Examples.new(@lti_token, current_application_instance)
       @lti_advantage_examples.run
+
+      if params[:lti_launch_token].present?
+        @lti_launch = LtiLaunch.find_by(
+          token: params[:lti_launch_token],
+          context_id: @lti_token[LtiAdvantage::Definitions::CONTEXT_CLAIM]["id"],
+        )
+
+        set_lti_launch_resource_link_id
+      end
     end
 
     setup_lti_response
@@ -24,7 +33,9 @@ class LtiLaunchesController < ApplicationController
 
   def show
     @lti_launch = LtiLaunch.find_by(token: params[:id], context_id: params[:context_id])
+    set_lti_launch_resource_link_id
     setup_lti_response
+
     render :index
   end
 
@@ -60,4 +71,14 @@ class LtiLaunchesController < ApplicationController
     set_lti_launch_values
   end
 
+  def set_lti_launch_resource_link_id
+    return unless @lti_launch
+    return if @lti_launch.resource_link_id.present?
+
+    if @lti_token && @lti_token[LtiAdvantage::Definitions::RESOURCE_LINK_CLAIM].present?
+      @lti_launch.update(resource_link_id: @lti_token[LtiAdvantage::Definitions::RESOURCE_LINK_CLAIM]["id"])
+    elsif params[:resource_link_id].present?
+      @lti_launch.update(resource_link_id: params[:resource_link_id])
+    end
+  end
 end

--- a/db/migrate/20210210195029_add_resource_link_id_to_lti_launches.rb
+++ b/db/migrate/20210210195029_add_resource_link_id_to_lti_launches.rb
@@ -1,0 +1,5 @@
+class AddResourceLinkIdToLtiLaunches < ActiveRecord::Migration[5.2]
+  def change
+    add_column :lti_launches, :resource_link_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_195556) do
+ActiveRecord::Schema.define(version: 2021_02_10_195029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(version: 2020_09_14_195556) do
     t.string "token"
     t.string "context_id"
     t.string "tool_consumer_instance_guid"
+    t.string "resource_link_id"
     t.index ["context_id"], name: "index_lti_launches_on_context_id"
     t.index ["token", "context_id"], name: "index_lti_launches_on_token_and_context_id", unique: true
   end

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -4,7 +4,8 @@ def setup_canvas_lti_advantage(
   iss: "https://canvas.instructure.com",
   lti_user_id: SecureRandom.uuid,
   context_id: SecureRandom.hex(15),
-  message_type: "LtiResourceLinkRequest"
+  message_type: "LtiResourceLinkRequest",
+  resource_link_id: SecureRandom.hex
 )
   @iss = iss
   @client_id = client_id
@@ -12,6 +13,7 @@ def setup_canvas_lti_advantage(
   @context_id = context_id
   @deployment_id = "12653:#{@context_id}"
   @message_type = message_type
+  @resource_link_id = resource_link_id
 
   application_instance.site.url = "https://atomicjolt.instructure.com"
   application_instance.site.save!
@@ -39,6 +41,7 @@ def setup_canvas_lti_advantage(
       lti_user_id: @lti_user_id,
       context_id: @context_id,
       message_type: @message_type,
+      resource_link_id: @resource_link_id,
     ),
     jwk.private_key,
     jwk.alg,
@@ -86,10 +89,10 @@ def setup_lti_advantage_users
   )
 end
 
-def resource_link_claim
+def resource_link_claim(id)
   {
     "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
-      "id": "af9b5e18fe251409be18e77253d918dcf22d156e",
+      "id": id,
       "description": nil,
       "title": nil,
       "validation_context": nil,
@@ -117,7 +120,7 @@ def deep_link_settings_claim
   }
 end
 
-def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
+def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:, resource_link_id:)
   exp = 24.hours.from_now
   nonce = SecureRandom.hex(10)
   payload = {
@@ -206,7 +209,7 @@ def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:)
     },
   }
 
-  payload.merge!(resource_link_claim) if @message_type == "LtiResourceLinkRequest"
+  payload.merge!(resource_link_claim(resource_link_id)) if @message_type == "LtiResourceLinkRequest"
   payload.merge!(deep_link_settings_claim) if @message_type == "LtiDeepLinkingRequest"
 
   payload


### PR DESCRIPTION
This purpose of this branch is to start storing the `resource_link_id` associated with an LTI launch. Having the `resource_link_id` should allow us to better support course copy since it gives us more data on where a launch is coming from.

One thing that's worth mentioning is that the `resource_link_id` sent by Canvas when launching an application that's embeded in a page isn't correct. According to Matt, it's a bug in Canvas. In that scenario, the `resource_link_id` isn't helpful because it's the same as the course context ID. However, the `resource_link_id` is still useful for other scenarios such as assignments or external tools added as modules items. It should also be useful for in-page launches in LMSes other than Canvas.