### PR TITLE
Added missing GraphQL base input type

### DIFF
--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,2 @@
+class Types::BaseInputObject < GraphQL::Schema::InputObject
+end


### PR DESCRIPTION
This was missing from the GraphQL types, but it is referenced elsewhere in the app.