### PR TITLE
Fix oauth callback url

### DIFF
--- a/app/lib/integrations/canvas_api_support.rb
+++ b/app/lib/integrations/canvas_api_support.rb
@@ -95,7 +95,7 @@ module Integrations
         client_id: application_instance.oauth_key,
         client_secret: application_instance.oauth_secret,
         redirect_uri: Rails.application.routes.url_helpers.user_canvas_omniauth_callback_url(
-          host: CanvasApiSupport.oauth_host,
+          host: Integrations::CanvasApiSupport.oauth_host,
           protocol: "https",
         ),
         refresh_token: auth.refresh_token,

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,10 @@ OmniAuth.config.before_request_phase do |env|
 
   # Inject app_callback_url here so we don't trust the client value
   payload = request.params.to_h
-  payload["app_callback_url"] = Rails.application.routes.url_helpers.user_canvas_omniauth_callback_url
+  payload["app_callback_url"] = Rails.application.routes.url_helpers.user_canvas_omniauth_callback_url(
+    host: Integrations::CanvasApiSupport.oauth_host,
+    protocol: "https",
+  )
 
   OauthState.create!(state: state, payload: payload.to_json)
   env["omniauth.strategy"].options[:authorize_params].state = state


### PR DESCRIPTION
Specify the host so we get the subdomain included.
Also include the full module path in the canvas_api_support, to keep these two calls consistent.