### PR TITLE
Remove old secret_token

### DIFF
--- a/config/initializers/nuclear_secrets.rb
+++ b/config/initializers/nuclear_secrets.rb
@@ -18,7 +18,6 @@ NuclearSecrets.configure do |config|
     hello_world_lti_secret: String,
     admin_lti_secret: String,
     secret_key_base: String,
-    secret_token: String,
     deploy_env: String,
   }
 end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -43,7 +43,6 @@ Defaults: &defaults
 
   deploy_env: ""
   display_env: ""
-  secret_token: ""
 
 development:
   <<: *defaults


### PR DESCRIPTION
The secret_token is no longer used. It's an artifact from rails 3.2 and 4.0.

DEPRECATION WARNING: `secrets.secret_token` is deprecated in favor of `secret_key_base` and will be removed in Rails 6.0.

From the upgrade guide:
```
Rails 4.0 introduces ActiveSupport::KeyGenerator and uses this as a base from which to generate and verify signed cookies (among other things). Existing signed cookies generated with Rails 3.x will be transparently upgraded if you leave your existing secret_token in place and add the new secret_key_base
```