### PR TITLE
Switch action mailer default host to 100% secret based

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -139,7 +139,7 @@ Rails.application.configure do
 
   # ActionMailer Config
   config.action_mailer.default_url_options = {
-    host: "#{Application::ADMIN}.#{Rails.application.secrets.application_root_domain}",
+    host: Rails.application.secrets.mailer_default_url_host,
   }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
With rails 6.1 this hack no longer works as the autoloader doesn't load model data in this file anymore. We will just set the host in the secrets now.