### PR TITLE
Remove queues from jobs

### DIFF
--- a/app/jobs/ims_export_job.rb
+++ b/app/jobs/ims_export_job.rb
@@ -1,6 +1,4 @@
 class ImsExportJob < ApplicationJob
-  queue_as :ims_export
-
   retry_on StandardError, attempts: 16
 
   def perform(

--- a/app/jobs/ims_import_job.rb
+++ b/app/jobs/ims_import_job.rb
@@ -1,6 +1,4 @@
 class ImsImportJob < ApplicationJob
-  queue_as :ims_import
-
   retry_on StandardError, attempts: 16
 
   def perform(job_data)


### PR DESCRIPTION
Que will currently not process all queues by default with rails 6. We have to specify the queue now. So we will use the queue named `default` going forward.