### PR TITLE
Fix que time parse issue

### DIFF
--- a/config/initializers/que_time_fix.rb
+++ b/config/initializers/que_time_fix.rb
@@ -1,0 +1,8 @@
+# Fixes `TypeError (no implicit conversion of Time into String)` until we can go to version 1 of que.
+Que::Adapters::Base::CAST_PROCS[1184] = lambda do |value|
+  case value
+  when Time then value
+  when String then Time.parse(value)
+  else raise "Unexpected time class: #{value.class} (#{value.inspect})"
+  end
+end


### PR DESCRIPTION
Time needs to be explicitly parsed now. Que does it only in the newer version 1.0 beta.