### PR TITLE
Debug Info Panel

### DIFF
--- a/app/assets/stylesheets/client.scss
+++ b/app/assets/stylesheets/client.scss
@@ -1,3 +1,4 @@
 // Environment
 @import "partials/print";
 @import "partials/environment";
+@import "partials/debug";

--- a/app/assets/stylesheets/partials/_debug.scss
+++ b/app/assets/stylesheets/partials/_debug.scss
@@ -1,0 +1,59 @@
+#aj-debug {
+  position: absolute;
+  color: rgb(224, 222, 222);
+  bottom: 10px;
+  right: 10px;
+  z-index: 10;
+  border-color: transparent;
+  background-color: rgba(0, 0, 0, 0.897);
+  border-radius: 50%;
+  height: 40px;
+  width: 40px;
+
+  &:hover {
+    cursor: pointer;
+    background-color: rgba(32, 32, 32, 0.897);
+  }
+}
+
+.aj-debug-overlay {
+  z-index: 10;
+  color: rgb(224, 222, 222);
+  width: 400px;
+  height: 600px;
+  bottom: 10px;
+  right: 60px;
+  position: absolute;
+  border-radius: 10px;
+  background-color: rgba(0, 0, 0, 0.897);
+
+  &.hidden {
+    display: none;
+  }
+
+  &__content {
+    text-align: left;
+    padding: 10px;
+  }
+
+  &__item {
+    border-bottom: 1px solid rgb(58, 58, 58);
+
+    h4 {
+      font-weight: bold;
+      font-size: 15px;
+      display: inline-block;
+      margin-top: 8px;
+      margin-bottom: 5px;
+    }
+  }
+
+  &__missing {
+    text-align: center;
+    padding: 10px;
+  }
+
+  pre {
+    display: inline-block;
+  }
+}

--- a/app/controllers/lti_launches_controller.rb
+++ b/app/controllers/lti_launches_controller.rb
@@ -13,6 +13,15 @@ class LtiLaunchesController < ApplicationController
       render file: File.join(Rails.root, "public", "disabled.html")
     end
 
+    @debug_data = {
+      "Tenant Name" => Apartment::Tenant.current,
+      "App Name" => current_application.name,
+      "Client App" => current_application.client_application_name,
+      "LTI Key" => current_application_instance.lti_key,
+      "Domain" => current_application_instance.domain,
+      "Test" => "something long that will wrap onto the next line of stuff hi there :)",
+    }
+
     if @lti_token
       # LTI advantage example code
       @lti_advantage_examples = LtiAdvantage::Examples.new(@lti_token, current_application_instance)

--- a/app/controllers/lti_launches_controller.rb
+++ b/app/controllers/lti_launches_controller.rb
@@ -13,15 +13,7 @@ class LtiLaunchesController < ApplicationController
       render file: File.join(Rails.root, "public", "disabled.html")
     end
 
-    @debug_data = {
-      "Tenant Name" => Apartment::Tenant.current,
-      "App Name" => current_application.name,
-      "Client App" => current_application.client_application_name,
-      "LTI Key" => current_application_instance.lti_key,
-      "Domain" => current_application_instance.domain,
-      "Test" => "something long that will wrap onto the next line of stuff hi there :)",
-    }
-
+    debug_data
     if @lti_token
       # LTI advantage example code
       @lti_advantage_examples = LtiAdvantage::Examples.new(@lti_token, current_application_instance)
@@ -57,6 +49,17 @@ class LtiLaunchesController < ApplicationController
         "roles" => "Learner",
       },
     )
+  end
+
+  def debug_data
+    @debug_data = {
+      "Tenant Name" => Apartment::Tenant.current,
+      "App Name" => current_application.name,
+      "Client App" => current_application.client_application_name,
+      "LTI Key" => current_application_instance.lti_key,
+      "Domain" => current_application_instance.domain,
+      "Test" => "something long that will wrap onto the next line of stuff hi there :)",
+    }
   end
 
   # Support Open ID connect flow for LTI 1.3

--- a/app/views/layouts/_debug.html.erb
+++ b/app/views/layouts/_debug.html.erb
@@ -1,0 +1,32 @@
+<% if Rails.application.secrets.display_debug.present? -%>
+  <button id="aj-debug" title="Show Debug Information">
+    <span class="material-icons">
+    bug_report
+    </span>
+  </button>
+  <div class="aj-debug-overlay hidden">
+    <h3>Debug Info</h3>
+    <% if @debug_data -%>
+    <div class="aj-debug-overlay__content">
+      <% @debug_data.each do |key, value|%>
+        <div class="aj-debug-overlay__item">
+          <h4><%= key %></h4> -
+          <span><%= value %></span>
+        </div>
+      <% end %>
+    </div>
+    <% else -%>
+    <div class="aj-debug-overlay__missing">
+      <div>No debug data defined</div>
+      <div>Add a <pre>@debug_data</pre> hash to the rendering context to see it's values populated here</div>
+    </div>
+    <% end %>
+  </div>
+  <script type="text/javascript">
+    const debug = document.getElementById("aj-debug");
+    debug.addEventListener("click", () => {
+      const overlay = document.getElementsByClassName("aj-debug-overlay")[0];
+      overlay.classList.toggle("hidden")
+    });
+  </script>
+<% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   </head>
   <body>
     <%= render "layouts/show_environment" %>
+    <%= render 'layouts/debug' %>
     <%= render 'layouts/navigation' %>
     <div class="o-contain o-contain--small">
       <%= render 'layouts/messages' %>

--- a/app/views/layouts/client.html.erb
+++ b/app/views/layouts/client.html.erb
@@ -5,6 +5,7 @@
     <%= render 'layouts/head' %>
   </head>
   <body>
+    <%= render 'layouts/debug' %>
     <%= render "layouts/show_environment" %>
     <%= yield %>
   </body>


### PR DESCRIPTION
# Purpose
Adds a panel to all LTI launch templates that is to be populated with various debug information for dev / beta use.

# Notes
- The populated data originates from a `@debug_info` hash present in the context of the template at render
- It's visibility is toggled on / off with the `display_debug` secret. 

# Images
## Minmized
![image](https://user-images.githubusercontent.com/24883544/126576088-d58b78d2-4670-402d-b7ea-5887f5dcf2b3.png)
## Maxamized
![image](https://user-images.githubusercontent.com/24883544/126576010-8925ea53-4449-48ae-8e1b-164130324cf4.png)
