### PR TITLE
disable hostname checking because rails 6 broke it

### DIFF
--- a/config/initializers/hosts.rb
+++ b/config/initializers/hosts.rb
@@ -1,3 +1,9 @@
 # Allow requests from subdomains like 'www.yourcustomdomain.com'
 # and 'blog.yourcustomdomain.com'.
 Rails.application.config.hosts << ".#{Rails.application.secrets.application_root_domain}"
+
+# Rails 6 no longer allows underscores in domain names, which we still use for
+# some clients. This disables the host checking, so the line above is
+# essentially unused until find a better way to handle this
+# https://github.com/rails/rails/issues/41545
+Rails.application.config.hosts.clear


### PR DESCRIPTION
This has been added to act but should in the other apps before they upgrade to rails 6