### PR TITLE
Add i18n support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -197,6 +197,8 @@ class ApplicationController < ActionController::Base
     @is_lti_launch = true
     @canvas_url = current_application_instance.site.url
     @app_name = current_application_instance.application.client_application_name
+    @launch_locale = params[:launch_presentation_locale]
+    set_i18n_locale
   end
 
   def set_lti_advantage_launch_values
@@ -210,6 +212,12 @@ class ApplicationController < ActionController::Base
     @app_name = current_application_instance.application.client_application_name
     @title = current_application_instance.application.name
     @description = current_application_instance.application.description
+  end
+
+  def set_i18n_locale
+    if locale = Localization.get_locale(@launch_locale) || Localization.get_default_locale(current_application_instance)
+      I18n.locale = locale
+    end
   end
 
   def targeted_app_instance

--- a/app/lib/localization.rb
+++ b/app/lib/localization.rb
@@ -1,0 +1,26 @@
+module Localization
+  # Map from LTI launch locale to app and client locale
+  LOCALES = {
+    "en" => "en",
+  }.freeze
+
+  # Return a valid locale or nil, if none
+  def self.get_locale(locale)
+    return nil if locale.blank?
+
+    short_locale = locale.split("-")[0]
+    if LOCALES[locale]
+      LOCALES[locale]
+    elsif LOCALES[short_locale]
+      LOCALES[short_locale]
+    else
+      nil
+    end
+  end
+
+  # Return a fallback locale based on the application instance
+  def self.get_default_locale(application_instance)
+    instance_locale = application_instance.get_config(:language)
+    get_locale(instance_locale) || "en"
+  end
+end

--- a/app/views/shared/_default_client_settings.html.erb
+++ b/app/views/shared/_default_client_settings.html.erb
@@ -7,6 +7,8 @@
   default_jwt = jwt_token(
     app_callback_url: user_canvas_omniauth_callback_url,
   )
+  settings[:language] = Localization.get_locale(params["launch_presentation_locale"]) || settings[:default_language]
+  settings[:default_language] = Localization.get_default_locale(current_application_instance)
 
   # OAuth related params
   settings[:canvas_oauth_url]     = user_canvas_omniauth_authorize_url(host: Integrations::CanvasApiSupport.oauth_host)

--- a/client/common/libs/i18n.js
+++ b/client/common/libs/i18n.js
@@ -1,0 +1,36 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+export async function initLocalization(components, language, defaultLanguage, i18n = i18next) {
+  await i18n
+    .use(initReactI18next) // passes i18n down to react-i18next
+    .init({
+      fallbackLng: [defaultLanguage, 'en'],
+      lng: language,
+
+      keySeparator: false, // we do not use keys in form messages.welcome
+      nsSeparator: false, // allow colons
+
+      interpolation: {
+        escapeValue: false // react already safes from xss
+      }
+    })
+
+  const languages = [...new Set([language])];
+  const promises = [];
+  languages.forEach(language => {
+    components.forEach(component => {
+      promises.push(
+        import(`../../locales/${language}/${component}.json`).then(resource => {
+          i18n.addResourceBundle(language, 'translation', resource.default.translation, true, true);
+          i18n.addResourceBundle(language, 'locale', resource.default.locale, true, true);
+        }).catch(reason => false)  // Ignore loading errors, since we don't know if the languages exist on our end
+      )
+    })
+  });
+
+  document.getElementsByTagName('body')[0].style.direction = i18n.dir(i18n.language);
+
+  await Promise.all(promises);
+
+}

--- a/client/common/libs/moment.js
+++ b/client/common/libs/moment.js
@@ -1,0 +1,8 @@
+import moment from 'moment-timezone';
+
+export function initMomentJS(languages, timezone) {
+  if (timezone) {
+    moment.tz.setDefault(timezone);
+  }
+  moment.locale(languages);
+}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -347,3 +347,10 @@ end
 ## Use this to update all the application instances
 # ApplicationInstance.for_tenant(Apartment::Tenant.current).find_each do |ai|
 # end
+
+## Add default language to all aplications
+Application.all.each do |app|
+  config = app.default_config
+  config[:language] = "en-US"
+  app.update!(default_config: config)
+end

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lodash": "4.17.21",
     "mime": "^2.4.4",
     "moment": "^2.29.1",
+    "moment-timezone": "^0.5.34",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-apollo": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6923,7 +6923,14 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.29.1:
+moment-timezone@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
This PR adds i18n support for both the rails app and react client.

The changes were backported from a MR in Socialize's GitLab Repo:
https://gitlab.com/atomicjolt/socialize/-/merge_requests/534
