### PR TITLE
Update graphql transform for Jest 28

### DIFF
--- a/jest.transform-graphql.js
+++ b/jest.transform-graphql.js
@@ -1,0 +1,13 @@
+// Copied from https://github.com/remind101/jest-transform-graphql
+// and updated for Jest 28 compatibility
+const loader = require('graphql-tag/loader');
+
+module.exports = {
+  process(src) {
+    // call directly the webpack loader with a mocked context
+    // as graphql-tag/loader leverages `this.cacheable()`
+    return {
+      code: loader.call({ cacheable() {} }, src)
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "<rootDir>/client"
     ],
     "transform": {
-      "\\.(gql|graphql)$": "jest-transform-graphql",
+      "\\.(gql|graphql)$": "./jest.transform-graphql",
       "^.+\\.jsx?$": "babel-jest"
     },
     "moduleNameMapper": {
@@ -118,7 +118,6 @@
     "eventsource-polyfill": "^0.9.6",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
-    "jest-transform-graphql": "^2.1.0",
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.4",
     "wait-for-expect": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7154,11 +7154,6 @@ jest-snapshot@^28.1.0:
     pretty-format "^28.1.0"
     semver "^7.3.5"
 
-jest-transform-graphql@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jest-transform-graphql/-/jest-transform-graphql-2.1.0.tgz#903cb66bb27bc2772fd3e5dd4f7e9b57230f5829"
-  integrity sha1-kDy2a7J7wncv0+XdT36bVyMPWCk=
-
 jest-util@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.0.tgz#d54eb83ad77e1dd441408738c5a5043642823be5"


### PR DESCRIPTION
The jest-transform-graphql project is unmaintained, so removing it and copying one tiny file
into the project.

https://www.pivotaltracker.com/story/show/182792861
